### PR TITLE
Uhm 5842 1

### DIFF
--- a/docs/examples/partitioning/README.md
+++ b/docs/examples/partitioning/README.md
@@ -1,0 +1,82 @@
+PETL - Partitioning Example
+==========================
+
+This example aims to demonstrate how one can use a variety of PETL jobs together to efficiently load a unified
+target reporting database from multiple source databases.  This example demonstrates many of PETL's capabilities,
+in terms of the breadth of job types used, execution modes, and more sophisticated techniques.
+
+This example simulates the effect of connecting to different database instances by instead connecting to a single
+database instance but reading a subset of data each time, and merging these into a target table.
+
+## How to run this example
+
+### Install and configure PETL to a test environment
+
+1. Create a PETL Home directory, and copy the included [datasources](./datasources) and [jobs](./jobs) directories here.
+2. Copy the provided [application.yml](./application.yml) file into this PETL home directory
+3. Build this project and copy the jar file from the target directory into this PETL home directory
+
+### Prepare a source OpenMRS MySQL database to use
+
+The query in this example uses data from the encounter table, specifically one with a variety of encounters at 3 locations 
+with the following names:  'Sal Gason', 'Sal Fanm', 'Sal Izolman'.  Using a backup of, or connecting directly to, HUM-CI 
+provides a good source environment with a decent and variable amount of purely test data. Once you have this database 
+available, update the configuration settings to match in [application.yml](./application.yml)
+
+### Prepare a target SqlServer database to use.
+
+The [Docker Compose](./docker-compose.yml) file included will enable you to get a SQL Server instance up if you don't 
+otherwise have one available.  Simply edit this file to specify the SA password that you wish to use, and run "docker-compose up -d" 
+from the directory containin this file.  You will be able to connect to this using your SQL client of choice (Intellij, Toad, etc).  
+Update the configuration settings to match in [application.yml](./application.yml)
+
+Connect to this as the SA user and create the target database:
+```CREATE DATABASE openmrs_reporting;```
+
+### Execute the job
+
+From your PETL home directory, execute:
+```java -jar petl.jar```
+
+## Features highlighted in this example
+
+### Startup Jobs
+
+Startup jobs provide a mechanism to execute a specific set of jobs at the time of PETL startup and prior to any other
+jobs that are auto-detected and executed in the jobs directory.  This provides two main benefits:
+
+#### Initialization
+
+Any initialization setup can be done here that is shared by multiple jobs.  In this case, we are executing 
+[initialize.yml](./jobs/initialize.yml), which is a SQL execution job that executes a series of SQL scripts against the
+target database.  This allows us to do things like [create shared functions](./jobs/function-num-columns-changed.sql) and 
+[procedures](./jobs/function-drop-table-if-exists.sql), or setup database-wide objects like 
+[partition functions and schemes](./jobs/initialize-partitions.sql).
+
+#### Testing
+
+If we are testing a particular job or testing changes to the PETL codebase, it may be easiest to add the job that you are 
+testing with to the startupJobs, as this bypasses the scheduling of the job and executes immediately at startup
+
+### Loading from multiple sources into a single table using partitioning
+
+The overall process is this:
+
+Use a [job-pipeline](./jobs/load-encounters.yml) to execute the following in series:
+
+**Job 1:**
+
+Use a **SQL Execution Job** to:
+
+* [Create a table](./jobs/encounters_schema.sql) to contain the unified data using this partition function. 
+* [Recreate this table any time the schema changes](./jobs/encounters_recreate_schema_if_needed.sql).
+
+**Job 2:**
+
+Use an **Iterating Job**
+
+* Iterate across all of our data sources, and execute each (up to 10) concurrently, with up to 5 attempts per iteration
+
+* [Drop and create a table](./jobs/encounters_drop_and_create.sql) to use just to load data for this iteration
+* [Extract data from the datasource](./jobs/encounters_extract_query.sql) into this table (we simulate using different datasources by having different table rows)
+* [Moving data into the unified table](./jobs/encounters_move_partition.sql) by moving the partition over and dropping the iteration-specific table.

--- a/docs/examples/partitioning/application.yml
+++ b/docs/examples/partitioning/application.yml
@@ -1,0 +1,31 @@
+petl:
+  homeDir: "<specify>"
+  datasourceDir: "${homeDir}/datasources"
+  jobDir: "${homeDir}/jobs"
+  startup:
+    jobs:
+      - "initialize.yml"
+      - "load-encounters.yml"
+
+mysql:
+  host: "<specify>"
+  port: "<specify>"
+  databaseName: "<specify>"
+  user: "<specify>"
+  password: "<specify>"
+  options: "autoReconnect=true&sessionVariables=default_storage_engine%3DInnoDB&useUnicode=true&characterEncoding=UTF-8&serverTimezone=US/Eastern"
+
+sqlserver:
+  host: "localhost"
+  port: "1433"
+  databaseName: "openmrs_reporting"
+  user: "sa"
+  password: "<specify>"
+
+server:
+  port: 9109
+  
+logging:
+  level:
+    root: "WARN"
+    org.pih: "DEBUG"

--- a/docs/examples/partitioning/datasources/openmrs_mysql.yml
+++ b/docs/examples/partitioning/datasources/openmrs_mysql.yml
@@ -1,0 +1,7 @@
+databaseType: "mysql"
+host: ${mysql.host}
+port: ${mysql.port}
+databaseName: ${mysql.databaseName}
+user: ${mysql.user}
+password: ${mysql.password}
+options: ${mysql.options}

--- a/docs/examples/partitioning/datasources/openmrs_reporting_sqlserver.yml
+++ b/docs/examples/partitioning/datasources/openmrs_reporting_sqlserver.yml
@@ -1,0 +1,6 @@
+databaseType: "sqlserver"
+host: ${sqlserver.host}
+port: ${sqlserver.port}
+databaseName: ${sqlserver.databaseName}
+user: ${sqlserver.user}
+password: ${sqlserver.password}

--- a/docs/examples/partitioning/docker-compose.yml
+++ b/docs/examples/partitioning/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '2'
+
+services:
+  sqlserver:
+    image: mcr.microsoft.com/mssql/server:2019-CU13-ubuntu-20.04
+    environment:
+      ACCEPT_EULA: "Y"
+      SA_PASSWORD: "<specify>"
+    ports:
+      - "1433:1433"
+

--- a/docs/examples/partitioning/jobs/encounters_drop_and_create.sql
+++ b/docs/examples/partitioning/jobs/encounters_drop_and_create.sql
@@ -1,0 +1,2 @@
+EXEC dbo.DROP_TABLE_IF_EXISTS 'encounters_${partition_num}';
+EXEC dbo.CREATE_ENCOUNTERS_TABLE '_${partition_num}';

--- a/docs/examples/partitioning/jobs/encounters_extract_query.sql
+++ b/docs/examples/partitioning/jobs/encounters_extract_query.sql
@@ -1,0 +1,5 @@
+select '${site}' as site, e.patient_id, e.encounter_id, e.encounter_datetime, et.name as encounter_type, l.name as location, e.date_created, ${partition_num} as partition_num
+from encounter e
+inner join encounter_type et on e.encounter_type = et.encounter_type_id
+inner join location l on e.location_id = l.location_id
+and l.name = '${locationName}';

--- a/docs/examples/partitioning/jobs/encounters_move_partition.sql
+++ b/docs/examples/partitioning/jobs/encounters_move_partition.sql
@@ -1,0 +1,4 @@
+
+TRUNCATE TABLE encounters WITH (PARTITIONS (${partition_num}));
+ALTER TABLE encounters_${partition_num} SWITCH PARTITION ${partition_num} TO encounters PARTITION ${partition_num};
+DROP TABLE encounters_${partition_num};

--- a/docs/examples/partitioning/jobs/encounters_recreate_schema_if_needed.sql
+++ b/docs/examples/partitioning/jobs/encounters_recreate_schema_if_needed.sql
@@ -1,0 +1,11 @@
+
+CREATE_ENCOUNTERS_TABLE '_temp'
+
+IF (dbo.NUM_COLUMNS_CHANGED('encounters_temp', 'encounters') > 0)
+BEGIN
+  EXEC DROP_TABLE_IF_EXISTS 'encounters';
+  EXEC CREATE_ENCOUNTERS_TABLE '';
+END
+;
+
+DROP TABLE encounters_temp;

--- a/docs/examples/partitioning/jobs/encounters_schema.sql
+++ b/docs/examples/partitioning/jobs/encounters_schema.sql
@@ -1,0 +1,23 @@
+CREATE OR ALTER PROCEDURE dbo.CREATE_ENCOUNTERS_TABLE
+    @tableSuffix VARCHAR(255)
+AS
+BEGIN
+    DECLARE @CREATE_SQL NVARCHAR(1000);
+
+    SET @CREATE_SQL =
+        'CREATE TABLE dbo.encounters' + @tableSuffix + ' (' +
+        '   site		  VARCHAR(50),' +
+        '   patient_id           INT,' +
+        '   encounter_id	  INT,' +
+        '   encounter_datetime   DATETIME,' +
+        '   encounter_type       VARCHAR(100),' +
+        '   location    	  VARCHAR(100),' +
+        '   date_created         DATETIME,' +
+        '   partition_num	  INT' +
+        ') ' +
+        'ON psSite(partition_num);';
+    ;
+
+    EXEC(@CREATE_SQL);
+END;
+

--- a/docs/examples/partitioning/jobs/function-drop-table-if-exists.sql
+++ b/docs/examples/partitioning/jobs/function-drop-table-if-exists.sql
@@ -1,0 +1,17 @@
+
+-- Create utility procedure to drop a table if it exists
+
+CREATE OR ALTER PROCEDURE DROP_TABLE_IF_EXISTS
+    @tableName VARCHAR(255)
+AS
+BEGIN
+    DECLARE @DROP_SQL NVARCHAR(1000);
+    
+    IF OBJECT_ID(@tableName) IS NOT NULL
+    BEGIN
+    	SET @DROP_SQL = 'DROP TABLE ' + @tableName;
+    	EXEC(@DROP_SQL);
+    END
+END;
+
+

--- a/docs/examples/partitioning/jobs/function-num-columns-changed.sql
+++ b/docs/examples/partitioning/jobs/function-num-columns-changed.sql
@@ -1,0 +1,22 @@
+
+-- Create function to allow determination if a schema has changed
+
+CREATE OR ALTER FUNCTION NUM_COLUMNS_CHANGED(@t1 VARCHAR(255), @t2 VARCHAR(255))
+    RETURNS INT
+    WITH EXECUTE AS CALLER
+AS
+BEGIN
+    DECLARE @NumChanges INT;
+
+    SET @NumChanges = (
+        SELECT count(*)
+        FROM sys.dm_exec_describe_first_result_set (N'SELECT * FROM ' + @t1, NULL, 0) t1
+        FULL OUTER JOIN  sys.dm_exec_describe_first_result_set (N'SELECT * FROM ' + @t2, NULL, 0) t2 ON t1.name = t2.name
+        WHERE ((isnull(t1.name, '') != isnull(t2.name, '')) OR (isnull(t1.system_type_name, '') != isnull(t2.system_type_name, '')))
+    )
+    ;
+
+    RETURN(@NumChanges);
+END
+;
+

--- a/docs/examples/partitioning/jobs/initialize-partitions.sql
+++ b/docs/examples/partitioning/jobs/initialize-partitions.sql
@@ -1,0 +1,23 @@
+
+-- Create a partition function.  Start with 50 partitions, to allow for up to 50 distinct sites
+IF NOT EXISTS (SELECT * FROM sys.partition_functions WHERE name = N'pfSite')
+BEGIN
+CREATE PARTITION FUNCTION pfSite(INT) AS RANGE LEFT FOR VALUES (
+    1,2,3,4,5,6,7,8,9,10,
+    11,12,13,14,15,16,17,18,19,20,
+    21,22,23,24,25,26,27,28,29,30,
+    31,32,33,34,35,36,37,38,39,40,
+    41,42,43,44,45,46,47,48,49,50
+);
+END
+;
+
+-- Create partition scheme with this function
+IF NOT EXISTS (SELECT * FROM sys.partition_schemes WHERE name = N'psSite')
+BEGIN
+CREATE PARTITION SCHEME psSite
+    AS PARTITION pfSite
+    ALL TO ([Primary]);
+END
+;
+

--- a/docs/examples/partitioning/jobs/initialize.yml
+++ b/docs/examples/partitioning/jobs/initialize.yml
@@ -1,0 +1,7 @@
+type: "sql-execution"
+configuration:
+  datasource: "openmrs_reporting_sqlserver.yml"
+  scripts:
+    - "initialize-partitions.sql"
+    - "function-num-columns-changed.sql"
+    - "function-drop-table-if-exists.sql"

--- a/docs/examples/partitioning/jobs/load-encounters.yml
+++ b/docs/examples/partitioning/jobs/load-encounters.yml
@@ -1,0 +1,55 @@
+type: "job-pipeline"
+configuration:
+  jobs:
+    - type: "sql-execution"
+      configuration:
+        datasource: "openmrs_reporting_sqlserver.yml"
+        scripts:
+          - "encounters_schema.sql"
+          - "encounters_recreate_schema_if_needed.sql"
+
+    - type: "iterating-job"
+      configuration:
+        execution:
+          maxConcurrentJobs: 10
+          maxRetriesPerJob: 5
+          retryInterval: 1
+        jobTemplate:
+          type: "job-pipeline"
+          configuration:
+            jobs:
+              - type: "sql-execution"
+                configuration:
+                  datasource: "openmrs_reporting_sqlserver.yml"
+                  scripts:
+                    - "encounters_drop_and_create.sql"
+
+              - type: "sqlserver-bulk-import"
+                configuration:
+                  extract:
+                    datasource: "${extractDatasource}"
+                    query:  "encounters_extract_query.sql"
+                  load:
+                    datasource: "openmrs_reporting_sqlserver.yml"
+                    table: "encounters_${partition_num}"
+
+              - type: "sql-execution"
+                configuration:
+                  datasource: "openmrs_reporting_sqlserver.yml"
+                  scripts:
+                    - "encounters_move_partition.sql"
+        iterations:
+          - extractDatasource: "openmrs_mysql.yml"
+            locationName: 'Sal Gason'
+            site: "MENS_WARD"
+            partition_num: "1"
+
+          - extractDatasource: "openmrs_mysql.yml"
+            locationName: 'Sal Fanm'
+            site: "WOMENS_WARD"
+            partition_num: "2"
+
+          - extractDatasource: "openmrs_mysql.yml"
+            locationName: 'Sal Izolman'
+            site: "ISOLATION_WARD"
+            partition_num: "3"

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.pih</groupId>
     <artifactId>petl</artifactId>
-    <version>2.7.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>petl</name>

--- a/src/main/java/org/pih/petl/Application.java
+++ b/src/main/java/org/pih/petl/Application.java
@@ -13,6 +13,7 @@ import org.springframework.context.ApplicationContext;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
+import java.util.List;
 
 import static org.quartz.SimpleScheduleBuilder.simpleSchedule;
 
@@ -56,6 +57,14 @@ public class Application {
 
         // Reset any hung jobs
         app.getEtlService().markHungJobsAsRun();
+
+        // Get and execute any jobs configured to run at startup
+        List<String> startupJobs = app.getAppConfig().getStartupJobs();
+        log.info("STARTUP JOBS: " + startupJobs);
+        for (String job : startupJobs) {
+            log.info("Executing Startup Job: " + job);
+            app.getEtlService().executeJob(job);
+        }
 
         // Set up the schedule to check if any etl jobs need to execute every minute
         SimpleScheduleBuilder schedule = simpleSchedule().repeatForever().withIntervalInSeconds(60);

--- a/src/main/java/org/pih/petl/ApplicationConfig.java
+++ b/src/main/java/org/pih/petl/ApplicationConfig.java
@@ -19,7 +19,9 @@ import org.springframework.core.env.PropertySource;
 import org.springframework.stereotype.Component;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
@@ -36,6 +38,7 @@ public class ApplicationConfig {
     public static final String PETL_JOB_DIR = "petl.jobDir";
     public static final String PETL_DATASOURCE_DIR = "petl.datasourceDir";
     public static final String PETL_SCHEDULE_CRON = "petl.schedule.cron";
+    public static final String PETL_STARTUP_JOBS = "petl.startup.jobs";
 
     private Map<String, String> env = null;
 
@@ -127,6 +130,21 @@ public class ApplicationConfig {
         }
     }
 
+    public List<String> getStartupJobs() {
+        List<String> l = new ArrayList<>();
+        boolean allFound = false;
+        int index = 0;
+        while (!allFound) {
+            String val = environment.getProperty(PETL_STARTUP_JOBS + "[" + index++ + "]");
+            if (val != null) {
+                l.add(val);
+            }
+            else {
+                allFound = true;
+            }
+        }
+        return l;
+    }
 
     /**
      * Convenience method to retrieve a PETL Job Config with the given path

--- a/src/main/java/org/pih/petl/ApplicationConfig.java
+++ b/src/main/java/org/pih/petl/ApplicationConfig.java
@@ -70,7 +70,7 @@ public class ApplicationConfig {
      * @return the File representing the PETL_HOME directory
      */
     public File getDirectoryFromEnvironment(String envName, boolean required) {
-        log.debug("Loading " + envName + " from environment");
+        log.trace("Loading " + envName + " from environment");
         String path = environment.getProperty(envName);
         if (StringUtils.isBlank(path)) {
             if (required) {
@@ -80,7 +80,7 @@ public class ApplicationConfig {
                 return null;
             }
         }
-        log.debug(envName + " configuration found: " + path);
+        log.trace(envName + " configuration found: " + path);
         File dir = new File(path);
         if (!dir.exists() || !dir.isDirectory()) {
             String message = envName + " = " + path + " does not point to a valid directory";

--- a/src/main/java/org/pih/petl/PetlUtil.java
+++ b/src/main/java/org/pih/petl/PetlUtil.java
@@ -1,12 +1,25 @@
 package org.pih.petl;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.apache.commons.io.IOUtils;
 
 import java.io.FileInputStream;
 import java.io.InputStream;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Properties;
 
 public class PetlUtil {
+
+    /**
+     * @return a standard Yaml mapper that can be used for processing YML files
+     */
+    public static ObjectMapper getYamlMapper() {
+        return new ObjectMapper(new YAMLFactory());
+    }
 
     /**
      * @return a Properties object based on a properties file on the classpath at the specified location
@@ -25,5 +38,33 @@ public class PetlUtil {
             IOUtils.closeQuietly(is);
         }
         return ret;
+    }
+
+    public static String getJsonAsString(JsonNode jsonNode) {
+        try {
+            return getYamlMapper().writeValueAsString(jsonNode);
+        }
+        catch (Exception e) {
+            throw new IllegalStateException("Unable to write Object as string");
+        }
+    }
+
+    public static JsonNode readJsonFromString(String jsonString) {
+        try {
+            return getYamlMapper().readTree(jsonString);
+        }
+        catch (Exception e) {
+            throw new IllegalStateException("Unable to read Object from string");
+        }
+    }
+
+    public static Map<String, String> getJsonAsMap(JsonNode jsonNode) {
+        Map<String, String> m = new LinkedHashMap<>();
+        for (Iterator<String> i = jsonNode.fieldNames(); i.hasNext();) {
+            String fieldName = i.next();
+            String fieldValue = jsonNode.get(fieldName).asText();
+            m.put(fieldName, fieldValue);
+        }
+        return m;
     }
 }

--- a/src/main/java/org/pih/petl/api/EtlService.java
+++ b/src/main/java/org/pih/petl/api/EtlService.java
@@ -51,7 +51,7 @@ public class EtlService {
         File jobDir = applicationConfig.getJobDir();
         if (jobDir != null) {
             final Path configPath = jobDir.toPath();
-            log.debug("Loading configured jobs from: " + configPath);
+            log.trace("Loading configured jobs from: " + configPath);
             try {
                 Files.walkFileTree(configPath, new SimpleFileVisitor<Path>() {
 
@@ -77,7 +77,7 @@ public class EtlService {
             }
         }
         else {
-            log.debug("No Job Directory configured, not returning any available jobs");
+            log.warn("No Job Directory configured, not returning any available jobs");
         }
         return m;
     }

--- a/src/main/java/org/pih/petl/api/JobExecutionResult.java
+++ b/src/main/java/org/pih/petl/api/JobExecutionResult.java
@@ -1,0 +1,36 @@
+package org.pih.petl.api;
+
+import org.pih.petl.job.PetlJob;
+import org.pih.petl.job.config.PetlJobConfig;
+import org.pih.petl.job.config.PetlJobFactory;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Represents the result of executing a JobExecutionTask
+ */
+public class JobExecutionResult {
+
+    private boolean successful;
+    private Throwable exception;
+
+    public JobExecutionResult() {
+    }
+
+    public boolean isSuccessful() {
+        return successful;
+    }
+
+    public void setSuccessful(boolean successful) {
+        this.successful = successful;
+    }
+
+    public Throwable getException() {
+        return exception;
+    }
+
+    public void setException(Throwable exception) {
+        this.exception = exception;
+    }
+}

--- a/src/main/java/org/pih/petl/api/JobExecutionResult.java
+++ b/src/main/java/org/pih/petl/api/JobExecutionResult.java
@@ -1,12 +1,5 @@
 package org.pih.petl.api;
 
-import org.pih.petl.job.PetlJob;
-import org.pih.petl.job.config.PetlJobConfig;
-import org.pih.petl.job.config.PetlJobFactory;
-
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
 /**
  * Represents the result of executing a JobExecutionTask
  */

--- a/src/main/java/org/pih/petl/api/JobExecutionTask.java
+++ b/src/main/java/org/pih/petl/api/JobExecutionTask.java
@@ -1,10 +1,12 @@
 package org.pih.petl.api;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.pih.petl.job.PetlJob;
+import org.pih.petl.job.config.ExecutionConfig;
 import org.pih.petl.job.config.PetlJobConfig;
 import org.pih.petl.job.config.PetlJobFactory;
 
-import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
@@ -13,42 +15,54 @@ import java.util.concurrent.TimeUnit;
  */
 public class JobExecutionTask implements Callable<JobExecutionResult> {
 
-    private List<PetlJobConfig> jobConfigs;
-    private ExecutionContext context;
-    private Integer maxRetries;
-    private Integer retryIntervalSeconds;
+    private static Log log = LogFactory.getLog(JobExecutionTask.class);
 
-    public JobExecutionTask(List<PetlJobConfig> jobConfigs, ExecutionContext context, Integer maxRetries, Integer retryIntervalSeconds) {
-        this.jobConfigs = jobConfigs;
+    private final PetlJobConfig jobConfig;
+    private final ExecutionContext context;
+    private final ExecutionConfig executionConfig;
+
+    public JobExecutionTask(PetlJobConfig jobConfig, ExecutionContext context, ExecutionConfig executionConfig) {
+        this.jobConfig = jobConfig;
         this.context = context;
-        this.maxRetries = maxRetries;
-        this.retryIntervalSeconds = retryIntervalSeconds;
+        this.executionConfig = executionConfig;
     }
 
     @Override
     public JobExecutionResult call() {
         JobExecutionResult result = new JobExecutionResult();
-        int maxAttempts = maxRetries == null ? 0 : maxRetries;
-        long retryInterval = (retryIntervalSeconds != null ? retryIntervalSeconds.longValue() : 60*5);
-        for (int currentAttempt = 0; !result.isSuccessful() && currentAttempt <= maxAttempts; currentAttempt++) {
-            context.setStatus("Executing job list: " + jobConfigs);
+        int maxRetries = executionConfig.getMaxRetriesPerJob() == null ? 0 : executionConfig.getMaxRetriesPerJob();
+        int retryInterval = executionConfig.getRetryInterval() == null ? 5 : executionConfig.getRetryInterval();
+        TimeUnit retryUnit = executionConfig.getRetryIntervalUnit() == null ? TimeUnit.MINUTES : executionConfig.getRetryIntervalUnit();
+        for (int currentAttempt = 0; !result.isSuccessful() && currentAttempt <= maxRetries; currentAttempt++) {
+            context.setStatus("Executing job: " + jobConfig);
             try {
-                for (PetlJobConfig jobConfig : jobConfigs) {
-                    PetlJob job = PetlJobFactory.instantiate(jobConfig);
-                    ExecutionContext nestedContext = new ExecutionContext(context.getJobExecution(), jobConfig, context.getApplicationConfig());
-                    context.setStatus("Executing job: " + job);
-                    job.execute(nestedContext);
-                }
+                PetlJob job = PetlJobFactory.instantiate(jobConfig);
+                ExecutionContext nestedContext = new ExecutionContext(context.getJobExecution(), jobConfig, context.getApplicationConfig());
+                context.setStatus("Executing job: " + job);
+                job.execute(nestedContext);
                 result.setSuccessful(true);
                 result.setException(null);
+                context.setTotalLoaded(context.getTotalLoaded() + 1);
             }
             catch (Throwable t) {
-                context.setStatus("An error occurred executing job.  This was attempt " + (currentAttempt+1) + "/" + maxAttempts + ". Will retry in " + retryInterval + " seconds");
+                result.setSuccessful(false);
                 result.setException(t);
-                try {
-                    TimeUnit.SECONDS.sleep(retryInterval);
+                StringBuilder status = new StringBuilder();
+                status.append("An error occurred executing job: " + t.getMessage());
+                if (currentAttempt < maxRetries) {
+                    status.append(". Will retry in ").append(retryInterval).append(" ").append(retryUnit).append(currentAttempt+1).append("/").append(maxRetries);
+                    context.setStatus(status.toString());
+                    try {
+                        retryUnit.sleep(retryInterval);
+                    }
+                    catch (InterruptedException e) {
+                        e.printStackTrace();
+                    }
                 }
-                catch (InterruptedException e) {}
+                else {
+                    context.setStatus(status.toString());
+                    log.error(t);
+                }
             }
         }
         return result;

--- a/src/main/java/org/pih/petl/api/JobExecutionTask.java
+++ b/src/main/java/org/pih/petl/api/JobExecutionTask.java
@@ -1,0 +1,56 @@
+package org.pih.petl.api;
+
+import org.pih.petl.job.PetlJob;
+import org.pih.petl.job.config.PetlJobConfig;
+import org.pih.petl.job.config.PetlJobFactory;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Represents an ETL job execution and the status of this
+ */
+public class JobExecutionTask implements Callable<JobExecutionResult> {
+
+    private List<PetlJobConfig> jobConfigs;
+    private ExecutionContext context;
+    private Integer maxRetries;
+    private Integer retryIntervalSeconds;
+
+    public JobExecutionTask(List<PetlJobConfig> jobConfigs, ExecutionContext context, Integer maxRetries, Integer retryIntervalSeconds) {
+        this.jobConfigs = jobConfigs;
+        this.context = context;
+        this.maxRetries = maxRetries;
+        this.retryIntervalSeconds = retryIntervalSeconds;
+    }
+
+    @Override
+    public JobExecutionResult call() {
+        JobExecutionResult result = new JobExecutionResult();
+        int maxAttempts = maxRetries == null ? 0 : maxRetries;
+        long retryInterval = (retryIntervalSeconds != null ? retryIntervalSeconds.longValue() : 60*5);
+        for (int currentAttempt = 0; !result.isSuccessful() && currentAttempt <= maxAttempts; currentAttempt++) {
+            context.setStatus("Executing job list: " + jobConfigs);
+            try {
+                for (PetlJobConfig jobConfig : jobConfigs) {
+                    PetlJob job = PetlJobFactory.instantiate(jobConfig);
+                    ExecutionContext nestedContext = new ExecutionContext(context.getJobExecution(), jobConfig, context.getApplicationConfig());
+                    context.setStatus("Executing job: " + job);
+                    job.execute(nestedContext);
+                }
+                result.setSuccessful(true);
+                result.setException(null);
+            }
+            catch (Throwable t) {
+                context.setStatus("An error occurred executing job.  This was attempt " + (currentAttempt+1) + "/" + maxAttempts + ". Will retry in " + retryInterval + " seconds");
+                result.setException(t);
+                try {
+                    TimeUnit.SECONDS.sleep(retryInterval);
+                }
+                catch (InterruptedException e) {}
+            }
+        }
+        return result;
+    }
+}

--- a/src/main/java/org/pih/petl/api/JobExecutionTask.java
+++ b/src/main/java/org/pih/petl/api/JobExecutionTask.java
@@ -50,7 +50,7 @@ public class JobExecutionTask implements Callable<JobExecutionResult> {
                 StringBuilder status = new StringBuilder();
                 status.append("An error occurred executing job: " + t.getMessage());
                 if (currentAttempt < maxRetries) {
-                    status.append(". Will retry in ").append(retryInterval).append(" ").append(retryUnit).append(currentAttempt+1).append("/").append(maxRetries);
+                    status.append(". Will retry in ").append(retryInterval).append(" ").append(retryUnit).append(" (").append(currentAttempt+1).append("/").append(maxRetries).append(")");
                     context.setStatus(status.toString());
                     try {
                         retryUnit.sleep(retryInterval);

--- a/src/main/java/org/pih/petl/api/JobExecutor.java
+++ b/src/main/java/org/pih/petl/api/JobExecutor.java
@@ -1,0 +1,32 @@
+package org.pih.petl.api;
+
+import org.pih.petl.job.config.ExecutionConfig;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+/**
+ * Responsible for executing jobs using ExecutorService
+ */
+public class JobExecutor {
+
+    public static void execute(List<JobExecutionTask> tasks, ExecutionContext context, ExecutionConfig config) throws InterruptedException, ExecutionException {
+        context.setStatus("Executing tasks");
+        ExecutorService executorService = Executors.newFixedThreadPool(config.getMaxConcurrentJobs());
+        List<Future<JobExecutionResult>> results = executorService.invokeAll(tasks);
+        executorService.shutdown();
+
+        // We only arrive here once all Tasks have been completed
+
+        for (Future<JobExecutionResult> resultFutures : results) {
+            JobExecutionResult result = resultFutures.get();
+            if (!result.isSuccessful()) {
+                throw new RuntimeException("Error in one of the jobs", result.getException());
+            }
+        }
+    }
+
+}

--- a/src/main/java/org/pih/petl/job/config/ConfigFile.java
+++ b/src/main/java/org/pih/petl/job/config/ConfigFile.java
@@ -1,8 +1,10 @@
 package org.pih.petl.job.config;
 
 import java.io.File;
+import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.text.StrSubstitutor;
 import org.pih.petl.PetlException;
 
 /**
@@ -39,6 +41,10 @@ public class ConfigFile {
         catch (Exception e) {
             throw new PetlException("Error reading " + configFile + ", please check that the file is valid", e);
         }
+    }
+
+    public String getContentsWithVariableReplacement(Map<String, String> replacements) {
+        return StrSubstitutor.replace(getContents(), replacements);
     }
 
     public File getFileDir() {

--- a/src/main/java/org/pih/petl/job/config/ExecutionConfig.java
+++ b/src/main/java/org/pih/petl/job/config/ExecutionConfig.java
@@ -1,0 +1,70 @@
+package org.pih.petl.job.config;
+
+import java.sql.Time;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Configures how execution threading, concurrency, and retries on error should be handled
+ * By default, an ExecutionConfig will specify no retries, and one concurrent job,
+ * but this can be adjusted to support executing jobs in parallel, and configuring the number of times a job
+ * execution should be attempted (i.e. to allow for retrying due to connectivity problems)
+ */
+public class ExecutionConfig {
+
+    private Integer maxConcurrentJobs = 1;
+    private Integer maxRetriesPerJob = 0;
+    private Integer retryInterval = 5;
+    private TimeUnit retryIntervalUnit = TimeUnit.MINUTES;
+
+    public ExecutionConfig() {
+    }
+
+    public ExecutionConfig(Integer maxConcurrentJobs, Integer maxRetriesPerJob, Integer retryInterval, TimeUnit retryIntervalUnit) {
+        this.maxConcurrentJobs = maxConcurrentJobs;
+        this.maxRetriesPerJob = maxRetriesPerJob;
+        this.retryInterval = retryInterval;
+        this.retryIntervalUnit = retryIntervalUnit;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("maxConcurrentJobs: ").append(maxConcurrentJobs).append(", retries: ").append(maxRetriesPerJob);
+        if (maxRetriesPerJob > 0) {
+            sb.append(" every ").append(retryInterval).append(" ").append(retryIntervalUnit);
+        }
+        return sb.toString();
+    }
+
+    public Integer getMaxConcurrentJobs() {
+        return maxConcurrentJobs;
+    }
+
+    public void setMaxConcurrentJobs(Integer maxConcurrentJobs) {
+        this.maxConcurrentJobs = maxConcurrentJobs;
+    }
+
+    public Integer getMaxRetriesPerJob() {
+        return maxRetriesPerJob;
+    }
+
+    public void setMaxRetriesPerJob(Integer maxRetriesPerJob) {
+        this.maxRetriesPerJob = maxRetriesPerJob;
+    }
+
+    public Integer getRetryInterval() {
+        return retryInterval;
+    }
+
+    public void setRetryInterval(Integer retryInterval) {
+        this.retryInterval = retryInterval;
+    }
+
+    public TimeUnit getRetryIntervalUnit() {
+        return retryIntervalUnit;
+    }
+
+    public void setRetryIntervalUnit(TimeUnit retryIntervalUnit) {
+        this.retryIntervalUnit = retryIntervalUnit;
+    }
+}

--- a/src/main/java/org/pih/petl/job/config/JobConfiguration.java
+++ b/src/main/java/org/pih/petl/job/config/JobConfiguration.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.ValueNode;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.pih.petl.PetlUtil;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -42,6 +43,19 @@ public class JobConfiguration {
             }
         }
         return ret;
+    }
+
+    public <T> T getObject(Class<T> type, String... keys) {
+        JsonNode n = get(keys);
+        if (n != null) {
+            try {
+                return PetlUtil.getYamlMapper().treeToValue(n, type);
+            }
+            catch (Exception e) {
+                throw new IllegalArgumentException("Unable to read json into " + type.getSimpleName());
+            }
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/org/pih/petl/job/config/JobConfiguration.java
+++ b/src/main/java/org/pih/petl/job/config/JobConfiguration.java
@@ -55,6 +55,14 @@ public class JobConfiguration {
         return null;
     }
 
+    public Integer getInt(Integer defaultValue, String...keys) {
+        JsonNode n = get(keys);
+        if (n != null) {
+            return n.asInt();
+        }
+        return defaultValue;
+    }
+
     /**
      * Convenience to get the configuration of a given setting as a String
      */

--- a/src/main/java/org/pih/petl/job/config/JobConfiguration.java
+++ b/src/main/java/org/pih/petl/job/config/JobConfiguration.java
@@ -1,0 +1,164 @@
+package org.pih.petl.job.config;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.ValueNode;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Encapsulates a particular ETL job configuration
+ */
+public class JobConfiguration {
+
+    private static final Log log = LogFactory.getLog(JobConfiguration.class);
+
+    private JsonNode configuration;
+    private Map<String, String> variables = new HashMap<>();
+
+    public JobConfiguration(JsonNode configuration) {
+        this.configuration = configuration;
+    }
+
+    /**
+     * @return the configuration setting at the nested level of configuration
+     */
+    public JsonNode get(String... keys) {
+        if (configuration == null || keys == null || keys.length == 0) {
+            return configuration;
+        }
+        JsonNode ret = configuration.get(keys[0]);
+        for (int i=1; i<keys.length; i++) {
+            if (ret != null) {
+                ret = ret.get(keys[i]);
+            }
+        }
+        return ret;
+    }
+
+    /**
+     * Convenience to get the configuration of a given setting as a String
+     */
+    public String getString(String... keys) {
+        JsonNode n = get(keys);
+        if (n != null) {
+            return n.asText();
+        }
+        return null;
+    }
+
+    /**
+     * Convenience to get the configuration of a given setting as a String
+     */
+    public boolean getBoolean(Boolean defaultValue, String... keys) {
+        JsonNode n = get(keys);
+        if (n != null) {
+            return n.asBoolean();
+        }
+        return defaultValue;
+    }
+
+    public boolean getBoolean(String... keys) {
+        return getBoolean(false, keys);
+    }
+
+    /**
+     * Convenience to get the configuration of a given setting as a String
+     */
+    public List<JsonNode> getList(String... keys) {
+        List<JsonNode> ret = new ArrayList();
+        JsonNode n = get(keys);
+        if (n != null) {
+            ArrayNode arrayNode = (ArrayNode)n;
+            for (JsonNode arrayMember : arrayNode) {
+                ret.add(arrayMember);
+            }
+        }
+        return ret;
+    }
+
+    /**
+     * Convenience to get the configuration of a given setting as a String
+     */
+    public List<String> getStringList(String... keys) {
+        List<String> ret = new ArrayList<>();
+        for (JsonNode n : getList(keys)) {
+            ret.add(n.asText());
+        }
+        return ret;
+    }
+
+    /**
+     * Converts the YML specified within the configuration element into a properties format for the PetlJob
+     */
+    public Properties getAsProperties() {
+        Properties p = new Properties();
+        p = addJsonNodeToProperties("", configuration, p);
+        return p;
+    }
+
+    /**
+     * Converts from a yml file to a properties file, using:
+     *   - dot notation (eg. object1.nestedObject2.property)
+     *   - array notation (eg. object1.nestedArray2[0].property)
+     */
+    private static Properties addJsonNodeToProperties(String propertyName, JsonNode node, Properties p) {
+        log.debug("Adding json node to properties: " + propertyName);
+        if (node.isObject()) {
+            log.debug("Node is an object");
+            ObjectNode objectNode = (ObjectNode) node;
+            for (Iterator<Map.Entry<String, JsonNode>> i = objectNode.fields(); i.hasNext();) {
+                Map.Entry<String, JsonNode> entry = i.next();
+                String newPropertyName = entry.getKey();
+                if (propertyName != null && !propertyName.equals("")) {
+                    newPropertyName = propertyName + "." + newPropertyName;
+                }
+                addJsonNodeToProperties(newPropertyName, entry.getValue(), p);
+            }
+        }
+        else if (node.isArray()) {
+            log.debug("Node is an array");
+            ArrayNode arrayNode = (ArrayNode) node;
+            for (int i = 0; i < arrayNode.size(); i++) {
+                addJsonNodeToProperties(propertyName + "[" + i + "]", arrayNode.get(i), p);
+            }
+        }
+        else if (node.isValueNode()) {
+            log.debug("Node is a value.");
+            ValueNode valueNode = (ValueNode) node;
+            String value = valueNode.textValue();
+            if (value != null) {
+                log.debug("Adding value at: " + propertyName + " = " + value);
+                p.put(propertyName, value);
+            }
+            else {
+                log.warn("Value is null");
+            }
+        }
+        return p;
+    }
+
+    public JsonNode getConfiguration() {
+        return configuration;
+    }
+
+    public void setConfiguration(JsonNode configuration) {
+        this.configuration = configuration;
+    }
+
+    public Map<String, String> getVariables() {
+        return variables;
+    }
+
+    public void setVariables(Map<String, String> variables) {
+        this.variables = variables;
+    }
+}

--- a/src/main/java/org/pih/petl/job/config/PetlJobConfig.java
+++ b/src/main/java/org/pih/petl/job/config/PetlJobConfig.java
@@ -24,117 +24,9 @@ public class PetlJobConfig {
     private ConfigFile configFile;
     private String type;
     private Schedule schedule;
-    private JsonNode configuration;
+    private JobConfiguration configuration;
 
     public PetlJobConfig() {}
-
-    /**
-     * @return the configuration setting at the nested level of configuration
-     */
-    public JsonNode get(String... keys) {
-        if (configuration == null || keys == null || keys.length == 0) {
-            return configuration;
-        }
-        JsonNode ret = configuration.get(keys[0]);
-        for (int i=1; i<keys.length; i++) {
-            if (ret != null) {
-                ret = ret.get(keys[i]);
-            }
-        }
-        return ret;
-    }
-
-    /**
-     * Convenience to get the configuration of a given setting as a String
-     */
-    public String getString(String... keys) {
-        JsonNode n = get(keys);
-        if (n != null) {
-            return n.asText();
-        }
-        return null;
-    }
-
-    /**
-     * Convenience to get the configuration of a given setting as a String
-     */
-    public boolean getBoolean(Boolean defaultValue, String... keys) {
-        JsonNode n = get(keys);
-        if (n != null) {
-            return n.asBoolean();
-        }
-        return defaultValue;
-    }
-
-    public boolean getBoolean(String... keys) {
-        return getBoolean(false, keys);
-    }
-
-    /**
-     * Convenience to get the configuration of a given setting as a String
-     */
-    public List<String> getStringList(String... keys) {
-        List ret = new ArrayList();
-        JsonNode n = get(keys);
-        if (n != null) {
-            ArrayNode arrayNode = (ArrayNode)n;
-            for (Iterator<JsonNode> i = arrayNode.iterator(); i.hasNext();) {
-                JsonNode arrayMember = i.next();
-                ret.add(arrayMember.asText());
-            }
-        }
-        return ret;
-    }
-
-    /**
-     * Converts the YML specified within the configuration element into a properties format for the PetlJob
-     */
-    public Properties getAsProperties() {
-        Properties p = new Properties();
-        p = addJsonNodeToProperties("", configuration, p);
-        return p;
-    }
-
-    /**
-     * Converts from a yml file to a properties file, using:
-     *   - dot notation (eg. object1.nestedObject2.property)
-     *   - array notation (eg. object1.nestedArray2[0].property)
-     */
-    private static Properties addJsonNodeToProperties(String propertyName, JsonNode node, Properties p) {
-        log.debug("Adding json node to properties: " + propertyName);
-        if (node.isObject()) {
-            log.debug("Node is an object");
-            ObjectNode objectNode = (ObjectNode) node;
-            for (Iterator<Map.Entry<String, JsonNode>> i = objectNode.fields(); i.hasNext();) {
-                Map.Entry<String, JsonNode> entry = i.next();
-                String newPropertyName = entry.getKey();
-                if (propertyName != null && !propertyName.equals("")) {
-                    newPropertyName = propertyName + "." + newPropertyName;
-                }
-                addJsonNodeToProperties(newPropertyName, entry.getValue(), p);
-            }
-        }
-        else if (node.isArray()) {
-            log.debug("Node is an array");
-            ArrayNode arrayNode = (ArrayNode) node;
-            for (int i = 0; i < arrayNode.size(); i++) {
-                addJsonNodeToProperties(propertyName + "[" + i + "]", arrayNode.get(i), p);
-            }
-        }
-        else if (node.isValueNode()) {
-            log.debug("Node is a value.");
-            ValueNode valueNode = (ValueNode) node;
-            String value = valueNode.textValue();
-            if (value != null) {
-                log.debug("Adding value at: " + propertyName + " = " + value);
-                p.put(propertyName, value);
-            }
-            else {
-                log.warn("Value is null");
-            }
-        }
-        return p;
-    }
 
     public ConfigFile getConfigFile() {
         return configFile;
@@ -160,11 +52,11 @@ public class PetlJobConfig {
         this.schedule = schedule;
     }
 
-    public JsonNode getConfiguration() {
+    public JobConfiguration getConfiguration() {
         return configuration;
     }
 
-    public void setConfiguration(JsonNode configuration) {
+    public void setConfiguration(JobConfiguration configuration) {
         this.configuration = configuration;
     }
 }

--- a/src/main/java/org/pih/petl/job/config/PetlJobFactory.java
+++ b/src/main/java/org/pih/petl/job/config/PetlJobFactory.java
@@ -22,7 +22,7 @@ public class PetlJobFactory {
         jobTypes.put("sqlserver-bulk-import", SqlServerImportJob.class);
         jobTypes.put("pentaho-job", PentahoJob.class);
         jobTypes.put("iterating-job", IteratingJob.class);
-        jobTypes.put("sql", SqlJob.class);
+        jobTypes.put("sql-execution", SqlJob.class);
     }
 
     /**

--- a/src/main/java/org/pih/petl/job/config/PetlJobFactory.java
+++ b/src/main/java/org/pih/petl/job/config/PetlJobFactory.java
@@ -5,8 +5,10 @@ import java.util.Map;
 
 import org.pih.petl.PetlException;
 import org.pih.petl.job.PetlJob;
+import org.pih.petl.job.type.IteratingJob;
 import org.pih.petl.job.type.PentahoJob;
 import org.pih.petl.job.type.RunMultipleJob;
+import org.pih.petl.job.type.SqlJob;
 import org.pih.petl.job.type.SqlServerImportJob;
 
 /**
@@ -19,6 +21,8 @@ public class PetlJobFactory {
         jobTypes.put("job-pipeline", RunMultipleJob.class);
         jobTypes.put("sqlserver-bulk-import", SqlServerImportJob.class);
         jobTypes.put("pentaho-job", PentahoJob.class);
+        jobTypes.put("iterating-job", IteratingJob.class);
+        jobTypes.put("sql", SqlJob.class);
     }
 
     /**

--- a/src/main/java/org/pih/petl/job/schedule/PetlScheduledExecutionTask.java
+++ b/src/main/java/org/pih/petl/job/schedule/PetlScheduledExecutionTask.java
@@ -50,48 +50,48 @@ public class PetlScheduledExecutionTask implements Job {
                 inProgress = true;
                 Schedule globalSchedule = applicationConfig.getSchedule();  // get the global schedule, if configured
                 Date currentDate = jobExecutionContext.getFireTime();
-                log.debug("Executing Task: " + currentDate);
+                log.trace("Executing Task: " + currentDate);
                 Map<String, PetlJobConfig> jobs = etlService.getAllConfiguredJobs();
-                log.debug("Found " + jobs.size() + " configured Jobs");
+                log.trace("Found " + jobs.size() + " configured Jobs");
                 for (String jobPath : jobs.keySet()) {
-                    log.debug("Checking job: " + jobPath);
+                    log.trace("Checking job: " + jobPath);
                     PetlJobConfig jobConfig = jobs.get(jobPath);
                     Schedule schedule = jobConfig.getSchedule() != null ? jobConfig.getSchedule() : globalSchedule;  // override global schedule with any local job-specific schedule
                     boolean isScheduled = schedule != null && StringUtils.isNotBlank(schedule.getCron());
                     if (isScheduled) {
                         JobExecution latestExecution = etlService.getLatestJobExecution(jobPath);
                         if (latestExecution == null) {
-                            log.info("Job: " + jobPath + " - Executing for the first time.");
+                            log.debug("Job: " + jobPath + " - Executing for the first time.");
                             etlService.executeJob(jobPath);
                         }
                         else {
                             Date lastStartDate = latestExecution.getStarted();
-                            log.debug("Last Execution Start: " + lastStartDate);
+                            log.trace("Last Execution Start: " + lastStartDate);
                             Date lastEndDate = latestExecution.getCompleted();
-                            log.debug("Last Execution End: " + lastEndDate);
+                            log.trace("Last Execution End: " + lastEndDate);
                             if (lastEndDate != null) {
-                                log.debug("Schedule found: " + schedule);
+                                log.trace("Schedule found: " + schedule);
                                 CronExpression cronExpression = new CronExpression(schedule.getCron());
                                 Date nextScheduledDate = cronExpression.getNextValidTimeAfter(lastStartDate);
-                                log.debug("Next scheduled for: " + nextScheduledDate);
+                                log.trace("Next scheduled for: " + nextScheduledDate);
                                 if (nextScheduledDate != null && nextScheduledDate.compareTo(currentDate) <= 0) {
-                                    log.info("Executing scheduled job: " + jobPath);
-                                    log.info("Last run: " + lastStartDate);
+                                    log.debug("Executing scheduled job: " + jobPath);
+                                    log.trace("Last run: " + lastStartDate);
                                     JobExecution execution = etlService.executeJob(jobPath);
                                     nextScheduledDate = cronExpression.getNextValidTimeAfter(execution.getStarted());
-                                    log.info("Scheduled job will run again at: " + nextScheduledDate);
+                                    log.trace("Scheduled job will run again at: " + nextScheduledDate);
                                 }
                                 else {
-                                    log.debug("This is in the future, not executing");
+                                    log.trace("This is in the future, not executing");
                                 }
                             }
                             else {
-                                log.debug("Latest execution is still in progress, not running again in parallel");
+                                log.trace("Latest execution is still in progress, not running again in parallel");
                             }
                         }
                     }
                     else {
-                        log.debug("Job has no scheduled associated with it, not executing.");
+                        log.trace("Job has no scheduled associated with it, not executing.");
                     }
                 }
             }

--- a/src/main/java/org/pih/petl/job/type/IteratingJob.java
+++ b/src/main/java/org/pih/petl/job/type/IteratingJob.java
@@ -1,0 +1,67 @@
+package org.pih.petl.job.type;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.commons.lang.text.StrSubstitutor;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.pih.petl.ApplicationConfig;
+import org.pih.petl.PetlUtil;
+import org.pih.petl.api.ExecutionContext;
+import org.pih.petl.job.PetlJob;
+import org.pih.petl.job.config.JobConfiguration;
+import org.pih.petl.job.config.PetlJobConfig;
+import org.pih.petl.job.config.PetlJobFactory;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Encapsulates a particular ETL job configuration
+ */
+public class IteratingJob implements PetlJob {
+
+    private static Log log = LogFactory.getLog(IteratingJob.class);
+
+    /**
+     * Creates a new instance of the job
+     */
+    public IteratingJob() {
+    }
+
+    /**
+     * @see PetlJob
+     */
+    @Override
+    public void execute(final ExecutionContext context) throws Exception {
+        ApplicationConfig appConfig = context.getApplicationConfig();
+        JobConfiguration config = context.getJobConfig().getConfiguration();
+
+        List<JsonNode> jobTemplates = config.getList("jobTemplates");
+        List<JsonNode> iterations = config.getList("iterations");
+
+        for (JsonNode iteration : iterations) {
+            Map<String, String> iterationVars = PetlUtil.getJsonAsMap(iteration);
+            context.setStatus("Executing iteration: " + iterationVars);
+            for (JsonNode jobTemplate : jobTemplates) {
+
+                PetlJobConfig petlJobConfig = new PetlJobConfig();
+                petlJobConfig.setType(jobTemplate.get("type").asText());
+                String configuration = PetlUtil.getJsonAsString(jobTemplate.get("configuration"));
+
+                Map<String, String> replacements = new HashMap<>(config.getVariables());
+                replacements.putAll(iterationVars);
+
+                configuration = StrSubstitutor.replace(configuration, replacements);
+                JobConfiguration jobConfiguration = new JobConfiguration(PetlUtil.readJsonFromString(configuration));
+                jobConfiguration.setVariables(replacements);
+                petlJobConfig.setConfiguration(jobConfiguration);
+
+                context.setStatus("Executing job: " + petlJobConfig.getType());
+                ExecutionContext nestedContext = new ExecutionContext(context.getJobExecution(), petlJobConfig, appConfig);
+                PetlJob job = PetlJobFactory.instantiate(petlJobConfig);
+                job.execute(nestedContext);
+            }
+        }
+    }
+}

--- a/src/main/java/org/pih/petl/job/type/IteratingJob.java
+++ b/src/main/java/org/pih/petl/job/type/IteratingJob.java
@@ -40,6 +40,8 @@ public class IteratingJob implements PetlJob {
         List<JsonNode> jobTemplates = config.getList("jobTemplates");
         List<JsonNode> iterations = config.getList("iterations");
 
+        // TODO:  Add in threading (run each iteration in a separate thread
+        // TODO:  Add retries on connection failure errorHanding.retryInterval, maxRetries, etc.
         for (JsonNode iteration : iterations) {
             Map<String, String> iterationVars = PetlUtil.getJsonAsMap(iteration);
             context.setStatus("Executing iteration: " + iterationVars);

--- a/src/main/java/org/pih/petl/job/type/IteratingJob.java
+++ b/src/main/java/org/pih/petl/job/type/IteratingJob.java
@@ -1,31 +1,24 @@
 package org.pih.petl.job.type;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import org.apache.commons.lang.text.StrSubstitutor;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.pih.petl.PetlUtil;
 import org.pih.petl.api.ExecutionContext;
-import org.pih.petl.api.JobExecutionResult;
 import org.pih.petl.api.JobExecutionTask;
+import org.pih.petl.api.JobExecutor;
 import org.pih.petl.job.PetlJob;
+import org.pih.petl.job.config.ExecutionConfig;
 import org.pih.petl.job.config.JobConfiguration;
 import org.pih.petl.job.config.PetlJobConfig;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Encapsulates a particular ETL job configuration
  */
 public class IteratingJob implements PetlJob {
-
-    private static Log log = LogFactory.getLog(IteratingJob.class);
 
     /**
      * Creates a new instance of the job
@@ -41,50 +34,21 @@ public class IteratingJob implements PetlJob {
         context.setStatus("Executing Iterating Job");
         JobConfiguration config = context.getJobConfig().getConfiguration();
 
-        List<JsonNode> jobTemplates = config.getList("jobTemplates");
+        JsonNode jobTemplate = config.get("jobTemplate");
         List<JsonNode> iterations = config.getList("iterations");
-
-        int maxConcurrentIterations = config.getInt(1, "execution", "maxConcurrentIterations");
-        int maxRetries = config.getInt(0, "execution", "maxRetries");
-        int retryIntervalSeconds = config.getInt(300, "execution", "retryIntervalSeconds");
-
-        ExecutorService executorService = Executors.newFixedThreadPool(maxConcurrentIterations);
-
+        ExecutionConfig executionConfig = config.getObject(ExecutionConfig.class, "execution");
+        if (executionConfig == null) {
+            executionConfig = new ExecutionConfig(1, 0, 5, TimeUnit.MINUTES);
+        }
+        context.setTotalExpected(iterations.size());
         List<JobExecutionTask> iterationTasks = new ArrayList<>();
         for (JsonNode iteration : iterations) {
             Map<String, String> iterationVars = PetlUtil.getJsonAsMap(iteration);
             context.setStatus("Adding iteration task: " + iterationVars);
-            List<PetlJobConfig> jobConfigs = new ArrayList<>();
-            for (JsonNode jobTemplate : jobTemplates) {
-
-                PetlJobConfig petlJobConfig = new PetlJobConfig();
-                petlJobConfig.setType(jobTemplate.get("type").asText());
-                String configuration = PetlUtil.getJsonAsString(jobTemplate.get("configuration"));
-
-                Map<String, String> replacements = new HashMap<>(config.getVariables());
-                replacements.putAll(iterationVars);
-
-                configuration = StrSubstitutor.replace(configuration, replacements);
-                JobConfiguration jobConfiguration = new JobConfiguration(PetlUtil.readJsonFromString(configuration));
-                jobConfiguration.setVariables(replacements);
-                petlJobConfig.setConfiguration(jobConfiguration);
-
-                jobConfigs.add(petlJobConfig);
-            }
-            iterationTasks.add(new JobExecutionTask(jobConfigs, context, maxRetries, retryIntervalSeconds));
+            PetlJobConfig jobConfig = context.getNestedJobConfig(jobTemplate, iterationVars);
+            iterationTasks.add(new JobExecutionTask(jobConfig, context, executionConfig));
         }
 
-        context.setStatus("Executing iteration tasks");
-        List<Future<JobExecutionResult>> results = executorService.invokeAll(iterationTasks);
-        executorService.shutdown();
-
-        // We only arrive here once all Tasks have been completed
-
-        for (Future<JobExecutionResult> resultFutures : results) {
-            JobExecutionResult result = resultFutures.get();
-            if (!result.isSuccessful()) {
-                throw new RuntimeException("Error in one of the jobs", result.getException());
-            }
-        }
+        JobExecutor.execute(iterationTasks, context, executionConfig);
     }
 }

--- a/src/main/java/org/pih/petl/job/type/PentahoJob.java
+++ b/src/main/java/org/pih/petl/job/type/PentahoJob.java
@@ -49,7 +49,7 @@ public class PentahoJob implements PetlJob {
 
         ApplicationConfig appConfig = context.getApplicationConfig();
         PetlJobConfig jobConfig = context.getJobConfig();
-        Properties configuration = jobConfig.getAsProperties();
+        Properties configuration = jobConfig.getConfiguration().getAsProperties();
 
         String jobFilePath = configuration.getProperty(JOB_FILE_PATH);
         log.debug("PetlJob file path: " + jobFilePath);

--- a/src/main/java/org/pih/petl/job/type/RunMultipleJob.java
+++ b/src/main/java/org/pih/petl/job/type/RunMultipleJob.java
@@ -7,6 +7,7 @@ import org.apache.commons.logging.LogFactory;
 import org.pih.petl.ApplicationConfig;
 import org.pih.petl.api.ExecutionContext;
 import org.pih.petl.job.PetlJob;
+import org.pih.petl.job.config.JobConfiguration;
 import org.pih.petl.job.config.PetlJobConfig;
 import org.pih.petl.job.config.PetlJobFactory;
 
@@ -29,7 +30,7 @@ public class RunMultipleJob implements PetlJob {
     @Override
     public void execute(final ExecutionContext context) throws Exception {
         ApplicationConfig appConfig = context.getApplicationConfig();
-        PetlJobConfig config = context.getJobConfig();
+        JobConfiguration config = context.getJobConfig().getConfiguration();
         List<String> jobs = config.getStringList("jobs");
         boolean parallelExecution = config.getBoolean("parallelExecution");
         context.setStatus("Executing " + jobs.size() + " in " + (parallelExecution ? "parallel" : "series"));

--- a/src/main/java/org/pih/petl/job/type/RunMultipleJob.java
+++ b/src/main/java/org/pih/petl/job/type/RunMultipleJob.java
@@ -1,15 +1,19 @@
 package org.pih.petl.job.type;
 
-import java.util.List;
-
+import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.pih.petl.ApplicationConfig;
 import org.pih.petl.api.ExecutionContext;
+import org.pih.petl.api.JobExecutionTask;
+import org.pih.petl.api.JobExecutor;
 import org.pih.petl.job.PetlJob;
+import org.pih.petl.job.config.ExecutionConfig;
 import org.pih.petl.job.config.JobConfiguration;
 import org.pih.petl.job.config.PetlJobConfig;
-import org.pih.petl.job.config.PetlJobFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Encapsulates a particular ETL job configuration
@@ -29,22 +33,21 @@ public class RunMultipleJob implements PetlJob {
      */
     @Override
     public void execute(final ExecutionContext context) throws Exception {
-        ApplicationConfig appConfig = context.getApplicationConfig();
         JobConfiguration config = context.getJobConfig().getConfiguration();
-        List<String> jobs = config.getStringList("jobs");
-        boolean parallelExecution = config.getBoolean("parallelExecution");
-        context.setStatus("Executing " + jobs.size() + " in " + (parallelExecution ? "parallel" : "series"));
-        context.setTotalExpected(jobs.size());
 
-        // TODO: Handle the ability to utilize the parallel execution and run jobs in parallel to each other
-        for (String jobPath : jobs) {
-            context.setStatus("Running job: " + jobPath);
-            PetlJobConfig nestedJobConfig = appConfig.getPetlJobConfig(jobPath);
-            ExecutionContext nestedContext = new ExecutionContext(context.getJobExecution(), nestedJobConfig, appConfig);
-            PetlJob job = PetlJobFactory.instantiate(nestedJobConfig);
-            job.execute(nestedContext);
-            // TODO: Periodically update overall context status from nested status, using thread.  See SqlServerImportJob
-            context.setTotalLoaded(context.getTotalLoaded() + 1);
+        List<JsonNode> jobTemplates = config.getList("jobs");
+        ExecutionConfig executionConfig = config.getObject(ExecutionConfig.class, "execution");
+        if (executionConfig == null) {
+            executionConfig = new ExecutionConfig(1, 0, 5, TimeUnit.MINUTES);
         }
+        context.setStatus("Executing " + jobTemplates.size() + " jobs using execution config: " + executionConfig);
+        context.setTotalExpected(jobTemplates.size());
+
+        List<JobExecutionTask> tasks = new ArrayList<>();
+        for (JsonNode jobTemplate : jobTemplates) {
+            PetlJobConfig petlJobConfig = context.getNestedJobConfig(jobTemplate, config.getVariables());
+            tasks.add(new JobExecutionTask(petlJobConfig, context, executionConfig));
+        }
+        JobExecutor.execute(tasks, context, executionConfig);
     }
 }

--- a/src/main/java/org/pih/petl/job/type/SqlJob.java
+++ b/src/main/java/org/pih/petl/job/type/SqlJob.java
@@ -12,6 +12,7 @@ import org.pih.petl.job.datasource.DatabaseUtil;
 import org.pih.petl.job.datasource.EtlDataSource;
 
 import java.sql.Connection;
+import java.sql.Statement;
 
 /**
  * Encapsulates a particular ETL job configuration
@@ -41,9 +42,10 @@ public class SqlJob implements PetlJob {
             ConfigFile sourceSqlFile = appConfig.getConfigFile(sqlFile);
             String sqlToExecute = sourceSqlFile.getContentsWithVariableReplacement(config.getVariables());
             try (Connection targetConnection = DatabaseUtil.openConnection(dataSource)) {
-                QueryRunner qr = new QueryRunner();
-                log.debug("Executing: " + sqlToExecute);
-                qr.update(targetConnection, sqlToExecute);
+                try (Statement statement = targetConnection.createStatement()) {
+                    log.trace("Executing: " + sqlToExecute);
+                    statement.execute(sqlToExecute);
+                }
             }
         }
     }

--- a/src/main/java/org/pih/petl/job/type/SqlJob.java
+++ b/src/main/java/org/pih/petl/job/type/SqlJob.java
@@ -1,0 +1,50 @@
+package org.pih.petl.job.type;
+
+import org.apache.commons.dbutils.QueryRunner;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.pih.petl.ApplicationConfig;
+import org.pih.petl.api.ExecutionContext;
+import org.pih.petl.job.PetlJob;
+import org.pih.petl.job.config.ConfigFile;
+import org.pih.petl.job.config.JobConfiguration;
+import org.pih.petl.job.datasource.DatabaseUtil;
+import org.pih.petl.job.datasource.EtlDataSource;
+
+import java.sql.Connection;
+
+/**
+ * Encapsulates a particular ETL job configuration
+ */
+public class SqlJob implements PetlJob {
+
+    private static Log log = LogFactory.getLog(SqlJob.class);
+
+    /**
+     * Creates a new instance of the job
+     */
+    public SqlJob() {
+    }
+
+    /**
+     * @see PetlJob
+     */
+    @Override
+    public void execute(final ExecutionContext context) throws Exception {
+        context.setStatus("Executing SqlJob");
+        ApplicationConfig appConfig = context.getApplicationConfig();
+        JobConfiguration config = context.getJobConfig().getConfiguration();
+
+        EtlDataSource dataSource = appConfig.getEtlDataSource(config.getString("datasource"));
+        for (String sqlFile : config.getStringList("scripts")) {
+            context.setStatus("Executing Sql Script: " + sqlFile);
+            ConfigFile sourceSqlFile = appConfig.getConfigFile(sqlFile);
+            String sqlToExecute = sourceSqlFile.getContentsWithVariableReplacement(config.getVariables());
+            try (Connection targetConnection = DatabaseUtil.openConnection(dataSource)) {
+                QueryRunner qr = new QueryRunner();
+                log.debug("Executing: " + sqlToExecute);
+                qr.update(targetConnection, sqlToExecute);
+            }
+        }
+    }
+}

--- a/src/main/java/org/pih/petl/job/type/SqlServerImportJob.java
+++ b/src/main/java/org/pih/petl/job/type/SqlServerImportJob.java
@@ -95,7 +95,6 @@ public class SqlServerImportJob implements PetlJob {
         if (StringUtils.isNotEmpty(conditional)) {
             if (!testConditional(conditional)) {
                 context.setStatus("Conditional returned false, skipping");
-                log.info("Conditional returned false, skipping this job");
                 return;
             }
         }
@@ -131,23 +130,23 @@ public class SqlServerImportJob implements PetlJob {
 
                 // Parse the source query into statements
                 List<String> stmts = SqlStatementParser.parseSqlIntoStatements(sourceQuery, ";");
-                log.debug("Parsed extract query into " + stmts.size() + " statements");
+                log.trace("Parsed extract query into " + stmts.size() + " statements");
 
                 // Iterate over each statement, and execute.  The final statement is expected to select the data out.
                 for (Iterator<String> sqlIterator = stmts.iterator(); sqlIterator.hasNext();) {
                     String sqlStatement = sqlIterator.next();
                     Statement statement = null;
                     try {
-                        log.debug("Executing: " + sqlStatement);
+                        log.trace("Executing: " + sqlStatement);
                         StopWatch sw = new StopWatch();
                         sw.start();
                         if (sqlIterator.hasNext()) {
                             statement = sourceConnection.createStatement();
                             statement.execute(sqlStatement);
-                            log.debug("Statement executed");
+                            log.trace("Statement executed");
                         }
                         else {
-                            log.debug("This is the last statement, treat it as the extraction query");
+                            log.trace("This is the last statement, treat it as the extraction query");
                             statement = sourceConnection.prepareStatement(
                                     sqlStatement, ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY
                             );
@@ -183,7 +182,7 @@ public class SqlServerImportJob implements PetlJob {
                             }
                         }
                         sw.stop();
-                        log.debug("Statement executed in: " + sw.toString());
+                        log.trace("Statement executed in: " + sw);
                     }
                     finally {
                         DbUtils.closeQuietly(statement);

--- a/src/main/java/org/pih/petl/job/type/SqlServerImportJob.java
+++ b/src/main/java/org/pih/petl/job/type/SqlServerImportJob.java
@@ -14,7 +14,7 @@ import org.pih.petl.PetlException;
 import org.pih.petl.api.ExecutionContext;
 import org.pih.petl.job.PetlJob;
 import org.pih.petl.job.config.ConfigFile;
-import org.pih.petl.job.config.PetlJobConfig;
+import org.pih.petl.job.config.JobConfiguration;
 import org.pih.petl.job.datasource.DatabaseUtil;
 import org.pih.petl.job.datasource.EtlDataSource;
 import org.pih.petl.job.datasource.SqlStatementParser;
@@ -52,7 +52,7 @@ public class SqlServerImportJob implements PetlJob {
     public void execute(final ExecutionContext context) throws Exception {
 
         ApplicationConfig appConfig = context.getApplicationConfig();
-        PetlJobConfig config = context.getJobConfig();
+        JobConfiguration config = context.getJobConfig().getConfiguration();
 
         context.setStatus("Loading configuration");
 
@@ -65,13 +65,13 @@ public class SqlServerImportJob implements PetlJob {
         String sourceContextFileName = config.getString("extract", "context");
         if (sourceContextFileName != null) {
             ConfigFile sourceContextFile = appConfig.getConfigFile(sourceContextFileName);
-            sourceContextStatements = sourceContextFile.getContents();
+            sourceContextStatements = sourceContextFile.getContentsWithVariableReplacement(config.getVariables());
         }
 
         // Get source query
         String sourceQueryFileName = config.getString("extract", "query");
         ConfigFile sourceQueryFile = appConfig.getConfigFile(sourceQueryFileName);
-        String sourceQuery = sourceContextStatements + sourceQueryFile.getContents();
+        String sourceQuery = sourceContextStatements + sourceQueryFile.getContentsWithVariableReplacement(config.getVariables());
 
         // Get any conditional
         String conditional = config.getString("conditional");
@@ -86,7 +86,7 @@ public class SqlServerImportJob implements PetlJob {
         // Get target table schema
         String targetSchemaFilename = config.getString("load", "schema");
         ConfigFile targetSchemaFile = appConfig.getConfigFile(targetSchemaFilename);
-        String targetSchema = targetSchemaFile.getContents();
+        String targetSchema = targetSchemaFile.getContentsWithVariableReplacement(config.getVariables());
 
         // TODO: Add validation in
 

--- a/src/test/java/org/pih/petl/api/EtlServiceTest.java
+++ b/src/test/java/org/pih/petl/api/EtlServiceTest.java
@@ -28,7 +28,7 @@ public class EtlServiceTest {
     @Test
     public void testServiceLoadsAllConfiguredJobs() {
         Map<String, PetlJobConfig> configuredJobs = etlService.getAllConfiguredJobs();
-        Assert.assertEquals(9, configuredJobs.size());
+        Assert.assertEquals(10, configuredJobs.size());
         Assert.assertNotNull(configuredJobs.get("sqlserverimport/job.yml"));
         Assert.assertNotNull(configuredJobs.get("pentaho/job.yml"));
     }

--- a/src/test/java/org/pih/petl/api/EtlServiceTest.java
+++ b/src/test/java/org/pih/petl/api/EtlServiceTest.java
@@ -28,7 +28,7 @@ public class EtlServiceTest {
     @Test
     public void testServiceLoadsAllConfiguredJobs() {
         Map<String, PetlJobConfig> configuredJobs = etlService.getAllConfiguredJobs();
-        Assert.assertEquals(10, configuredJobs.size());
+        Assert.assertEquals(11, configuredJobs.size());
         Assert.assertNotNull(configuredJobs.get("sqlserverimport/job.yml"));
         Assert.assertNotNull(configuredJobs.get("pentaho/job.yml"));
     }

--- a/src/test/java/org/pih/petl/job/IteratingJobTest.java
+++ b/src/test/java/org/pih/petl/job/IteratingJobTest.java
@@ -1,0 +1,72 @@
+package org.pih.petl.job;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.pih.petl.ApplicationConfig;
+import org.pih.petl.SpringRunnerTest;
+import org.pih.petl.api.EtlService;
+import org.pih.petl.job.datasource.DatabaseUtil;
+import org.pih.petl.job.datasource.EtlDataSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.sql.Connection;
+
+/**
+ * Tests the SqlServerImportJob
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class IteratingJobTest {
+
+    @Autowired
+    EtlService etlService;
+
+    static {
+        SpringRunnerTest.setupEnvironment();
+    }
+
+    @After
+    public void dropTablesInTargetDB() throws Exception{
+        ApplicationConfig appConfig = etlService.getApplicationConfig();
+        EtlDataSource sqlServerDataSource = appConfig.getEtlDataSource("sqlserver-testcontainer.yml");
+        try (Connection c = DatabaseUtil.openConnection(sqlServerDataSource)) {
+            DatabaseUtil.dropTable(c, "encounter_types");
+        }
+    }
+
+    @Test
+    public void testJobWithSqlExecution() throws Exception {
+        etlService.executeJob("iteratingjob/jobWithSqlExecution.yml");
+        verifyTableExists("encounter_types");
+        verifyRowCount("encounter_types", 13);
+    }
+
+    public void verifyRowCount(String table, int expectedRows) throws Exception {
+        ApplicationConfig appConfig = etlService.getApplicationConfig();
+        EtlDataSource sqlServerDataSource = appConfig.getEtlDataSource("sqlserver-testcontainer.yml");
+        try (Connection c = DatabaseUtil.openConnection(sqlServerDataSource)) {
+            int rowsFound = DatabaseUtil.rowCount(c, table);
+            Assert.assertEquals(expectedRows, rowsFound);
+        }
+    }
+
+    public void verifyTableExists(String table) throws Exception {
+        ApplicationConfig appConfig = etlService.getApplicationConfig();
+        EtlDataSource sqlServerDataSource = appConfig.getEtlDataSource("sqlserver-testcontainer.yml");
+        try (Connection c = DatabaseUtil.openConnection(sqlServerDataSource)) {
+            Assert.assertTrue(DatabaseUtil.tableExists(c, "encounter_types"));
+        }
+    }
+
+    public void verifyTableDoesNotExist(String table) throws Exception {
+        ApplicationConfig appConfig = etlService.getApplicationConfig();
+        EtlDataSource sqlServerDataSource = appConfig.getEtlDataSource("sqlserver-testcontainer.yml");
+        try (Connection c = DatabaseUtil.openConnection(sqlServerDataSource)) {
+            Assert.assertFalse(DatabaseUtil.tableExists(c, "encounter_types"));
+        }
+    }
+}

--- a/src/test/java/org/pih/petl/job/IteratingJobTest.java
+++ b/src/test/java/org/pih/petl/job/IteratingJobTest.java
@@ -12,6 +12,7 @@ import org.pih.petl.job.datasource.DatabaseUtil;
 import org.pih.petl.job.datasource.EtlDataSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.sql.Connection;
@@ -21,6 +22,7 @@ import java.sql.Connection;
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest
+@TestPropertySource(properties = {"petl.jobDir = src/test/resources/configuration/jobs/iteratingjob"})
 public class IteratingJobTest {
 
     @Autowired
@@ -50,7 +52,7 @@ public class IteratingJobTest {
 
     @Test
     public void testJobWithSqlExecution() throws Exception {
-        etlService.executeJob("iteratingjob/jobWithSqlExecution.yml");
+        etlService.executeJob("jobWithSqlExecution.yml");
         verifyTableExists("encounter_types");
         verifyRowCount("encounter_types", 13);
     }

--- a/src/test/java/org/pih/petl/job/IteratingJobTest.java
+++ b/src/test/java/org/pih/petl/job/IteratingJobTest.java
@@ -2,6 +2,7 @@ package org.pih.petl.job;
 
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.pih.petl.ApplicationConfig;
@@ -29,7 +30,16 @@ public class IteratingJobTest {
         SpringRunnerTest.setupEnvironment();
     }
 
+    @Before
+    public void runBefore() throws Exception {
+        dropTablesInTargetDB();
+    }
+
     @After
+    public void runAfter() throws Exception {
+        dropTablesInTargetDB();
+    }
+
     public void dropTablesInTargetDB() throws Exception{
         ApplicationConfig appConfig = etlService.getApplicationConfig();
         EtlDataSource sqlServerDataSource = appConfig.getEtlDataSource("sqlserver-testcontainer.yml");

--- a/src/test/java/org/pih/petl/job/PentahoJobTest.java
+++ b/src/test/java/org/pih/petl/job/PentahoJobTest.java
@@ -6,6 +6,7 @@ import org.pih.petl.SpringRunnerTest;
 import org.pih.petl.api.EtlService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
 /**
@@ -13,6 +14,7 @@ import org.springframework.test.context.junit4.SpringRunner;
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest
+@TestPropertySource(properties = {"petl.jobDir = src/test/resources/configuration/jobs/pentaho"})
 public class PentahoJobTest {
 
     @Autowired
@@ -24,6 +26,6 @@ public class PentahoJobTest {
 
     @Test
     public void testSimpleJobThatOutputsLoggingMessage() {
-        etlService.executeJob("pentaho/job.yml");
+        etlService.executeJob("job.yml");
     }
 }

--- a/src/test/java/org/pih/petl/job/RunMultipleTest.java
+++ b/src/test/java/org/pih/petl/job/RunMultipleTest.java
@@ -2,6 +2,7 @@ package org.pih.petl.job;
 
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.pih.petl.ApplicationConfig;
@@ -21,8 +22,8 @@ import java.sql.Connection;
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest
-@TestPropertySource(properties = {"petl.jobDir = src/test/resources/configuration/jobs/sqlserverimport"})
-public class SqlServerImportJobTest {
+@TestPropertySource(properties = {"petl.jobDir = src/test/resources/configuration/jobs/runmultiple"})
+public class RunMultipleTest {
 
     @Autowired
     EtlService etlService;
@@ -31,7 +32,16 @@ public class SqlServerImportJobTest {
         SpringRunnerTest.setupEnvironment();
     }
 
+    @Before
+    public void runBefore() throws Exception {
+        dropTablesInTargetDB();
+    }
+
     @After
+    public void runAfter() throws Exception {
+        dropTablesInTargetDB();
+    }
+
     public void dropTablesInTargetDB() throws Exception{
         ApplicationConfig appConfig = etlService.getApplicationConfig();
         EtlDataSource sqlServerDataSource = appConfig.getEtlDataSource("sqlserver-testcontainer.yml");
@@ -41,59 +51,10 @@ public class SqlServerImportJobTest {
     }
 
     @Test
-    public void testLoadingFromMySQL() throws Exception {
-        etlService.executeJob("job.yml");
+    public void testJobWithSqlExecution() throws Exception {
+        etlService.executeJob("defaultExecution.yml");
         verifyTableExists("encounter_types");
         verifyRowCount("encounter_types", 62);
-
-        // by default, table should be dropped and recreated on each run, so consecutive runs should return the same result
-        etlService.executeJob("job.yml");
-        verifyTableExists("encounter_types");
-        verifyRowCount("encounter_types", 62);
-    }
-
-    @Test
-    public void testLoadingFromPostgres() throws Exception {
-        etlService.executeJob("jobPostgres.yml");
-        verifyTableExists("encounter_types");
-        verifyRowCount("encounter_types", 6);
-
-        // by default, table should be dropped and recreated on each run, so consecutive runs should return the same result
-        etlService.executeJob("jobPostgres.yml");
-        verifyTableExists("encounter_types");
-        verifyRowCount("encounter_types", 6);
-    }
-
-    @Test
-    public void testLoadingFromMySQLWithDropAndRecreateTableFalse() throws Exception {
-        etlService.executeJob("jobDropAndRecreateTableFalse.yml");
-        verifyTableExists("encounter_types");
-        verifyRowCount("encounter_types", 62);
-
-        etlService.executeJob("jobDropAndRecreateTableFalse.yml");
-        // since we aren't dropping the table, all rows should be inserts twice, doubling the result set
-        // (ignore fact that we really should have a key on uuid, which would result in duplicate key exception)
-        verifyRowCount("encounter_types", 124);
-    }
-
-    @Test
-    public void testConditionalTrue() throws Exception {
-        etlService.executeJob("jobConditionalTrue.yml");
-        verifyTableExists("encounter_types");
-        verifyRowCount("encounter_types", 62);
-    }
-
-    @Test
-    public void testLoadingWithContext() throws Exception {
-        etlService.executeJob("jobWithContext.yml");
-        verifyTableExists("encounter_types");
-        verifyRowCount("encounter_types", 4);
-    }
-
-    @Test
-    public void testConditionalFalse() throws Exception {
-        etlService.executeJob("jobConditionalFalse.yml");
-        verifyTableDoesNotExist("encounter_types");
     }
 
     public void verifyRowCount(String table, int expectedRows) throws Exception {

--- a/src/test/resources/configuration/jobs/iteratingjob/encounterTypesSchema.sql
+++ b/src/test/resources/configuration/jobs/iteratingjob/encounterTypesSchema.sql
@@ -1,6 +1,6 @@
 IF OBJECT_ID('encounter_types') IS NULL
     create table encounter_types (
         uuid CHAR(38),
-        name VARCHAR(100),
-        description VARCHAR(100)
+        name VARCHAR(500),
+        description VARCHAR(500)
     );

--- a/src/test/resources/configuration/jobs/iteratingjob/encounterTypesSchema.sql
+++ b/src/test/resources/configuration/jobs/iteratingjob/encounterTypesSchema.sql
@@ -1,0 +1,6 @@
+IF OBJECT_ID('encounter_types') IS NULL
+    create table encounter_types (
+        uuid CHAR(38),
+        name VARCHAR(100),
+        description VARCHAR(100)
+    );

--- a/src/test/resources/configuration/jobs/iteratingjob/encounterTypesStartingWithName.sql
+++ b/src/test/resources/configuration/jobs/iteratingjob/encounterTypesStartingWithName.sql
@@ -1,0 +1,3 @@
+select uuid, name, description
+from encounter_type
+where name like '${namePrefix}%';

--- a/src/test/resources/configuration/jobs/iteratingjob/jobWithSqlExecution.yml
+++ b/src/test/resources/configuration/jobs/iteratingjob/jobWithSqlExecution.yml
@@ -1,0 +1,37 @@
+type: "iterating-job"
+
+configuration:
+
+  jobTemplates:
+
+    - type: "sql-execution"
+      configuration:
+        datasource: "sqlserver-testcontainer.yml"
+        scripts:
+          - "iteratingjob/encounterTypesSchema.sql"
+
+    - type: "sqlserver-bulk-import"
+      configuration:
+        extract:
+          datasource: "${extractDatasource}"
+          query:  "iteratingjob/encounterTypesStartingWithName.sql"
+        load:
+          datasource: "sqlserver-testcontainer.yml"
+          table: "encounter_types"
+
+  iterations:
+
+    - extractDatasource: "mysql-testcontainer.yml"
+      namePrefix: 'Primary Care'
+      category: "PRIMARY_CARE"
+      partition_num: "1"
+
+    - extractDatasource: "mysql-testcontainer.yml"
+      namePrefix: 'ZL VIH'
+      category: "ZL_HIV"
+      partition_num: "2"
+
+    - extractDatasource: "mysql-testcontainer.yml"
+      namePrefix: 'ANC'
+      category: "ANC"
+      partition_num: "3"

--- a/src/test/resources/configuration/jobs/iteratingjob/jobWithSqlExecution.yml
+++ b/src/test/resources/configuration/jobs/iteratingjob/jobWithSqlExecution.yml
@@ -2,22 +2,26 @@ type: "iterating-job"
 
 configuration:
 
-  jobTemplates:
+  jobTemplate:
 
-    - type: "sql-execution"
-      configuration:
-        datasource: "sqlserver-testcontainer.yml"
-        scripts:
-          - "iteratingjob/encounterTypesSchema.sql"
+    type: "job-pipeline"
+    configuration:
+      jobs:
 
-    - type: "sqlserver-bulk-import"
-      configuration:
-        extract:
-          datasource: "${extractDatasource}"
-          query:  "iteratingjob/encounterTypesStartingWithName.sql"
-        load:
+      - type: "sql-execution"
+        configuration:
           datasource: "sqlserver-testcontainer.yml"
-          table: "encounter_types"
+          scripts:
+            - "encounterTypesSchema.sql"
+
+      - type: "sqlserver-bulk-import"
+        configuration:
+          extract:
+            datasource: "${extractDatasource}"
+            query:  "encounterTypesStartingWithName.sql"
+          load:
+            datasource: "sqlserver-testcontainer.yml"
+            table: "encounter_types"
 
   iterations:
 

--- a/src/test/resources/configuration/jobs/runmultiple/defaultExecution.yml
+++ b/src/test/resources/configuration/jobs/runmultiple/defaultExecution.yml
@@ -1,0 +1,17 @@
+type: "job-pipeline"
+configuration:
+  jobs:
+    - type: "sql-execution"
+      configuration:
+        datasource: "sqlserver-testcontainer.yml"
+        scripts:
+          - "encounterTypesSchema.sql"
+
+    - type: "sqlserver-bulk-import"
+      configuration:
+        extract:
+          datasource: "mysql-testcontainer.yml"
+          query:  "encounterTypesStartingWithName.sql"
+        load:
+          datasource: "sqlserver-testcontainer.yml"
+          table: "encounter_types"

--- a/src/test/resources/configuration/jobs/runmultiple/encounterTypesSchema.sql
+++ b/src/test/resources/configuration/jobs/runmultiple/encounterTypesSchema.sql
@@ -1,0 +1,5 @@
+create table encounter_types (
+    uuid CHAR(38),
+    name VARCHAR(500),
+    description VARCHAR(500)
+);

--- a/src/test/resources/configuration/jobs/runmultiple/encounterTypesStartingWithName.sql
+++ b/src/test/resources/configuration/jobs/runmultiple/encounterTypesStartingWithName.sql
@@ -1,0 +1,2 @@
+select uuid, name, description
+from encounter_type;

--- a/src/test/resources/configuration/jobs/sqlserverimport/job.yml
+++ b/src/test/resources/configuration/jobs/sqlserverimport/job.yml
@@ -2,9 +2,9 @@ type: "sqlserver-bulk-import"
 configuration:
   extract:
     datasource: "mysql-testcontainer.yml"
-    query:  "sqlserverimport/source.sql"
+    query:  "source.sql"
 
   load:
     datasource: "sqlserver-testcontainer.yml"
     table: "encounter_types"
-    schema: "sqlserverimport/target.sql"
+    schema: "target.sql"

--- a/src/test/resources/configuration/jobs/sqlserverimport/jobConditionalFalse.yml
+++ b/src/test/resources/configuration/jobs/sqlserverimport/jobConditionalFalse.yml
@@ -2,11 +2,11 @@ type: "sqlserver-bulk-import"
 configuration:
   extract:
     datasource: "mysql-testcontainer.yml"
-    query:  "sqlserverimport/source.sql"
+    query:  "source.sql"
 
   load:
     datasource: "sqlserver-testcontainer.yml"
     table: "encounter_types"
-    schema: "sqlserverimport/target.sql"
+    schema: "target.sql"
 
   conditional: "SELECT 1=2;"

--- a/src/test/resources/configuration/jobs/sqlserverimport/jobConditionalTrue.yml
+++ b/src/test/resources/configuration/jobs/sqlserverimport/jobConditionalTrue.yml
@@ -2,11 +2,11 @@ type: "sqlserver-bulk-import"
 configuration:
   extract:
     datasource: "mysql-testcontainer.yml"
-    query:  "sqlserverimport/source.sql"
+    query:  "source.sql"
 
   load:
     datasource: "sqlserver-testcontainer.yml"
     table: "encounter_types"
-    schema: "sqlserverimport/target.sql"
+    schema: "target.sql"
 
   conditional: "SELECT 1=1;"

--- a/src/test/resources/configuration/jobs/sqlserverimport/jobDropAndRecreateTableFalse.yml
+++ b/src/test/resources/configuration/jobs/sqlserverimport/jobDropAndRecreateTableFalse.yml
@@ -2,11 +2,11 @@ type: "sqlserver-bulk-import"
 configuration:
   extract:
     datasource: "mysql-testcontainer.yml"
-    query:  "sqlserverimport/source.sql"
+    query:  "source.sql"
 
   load:
     datasource: "sqlserver-testcontainer.yml"
     table: "encounter_types"
-    schema: "sqlserverimport/target.sql"
+    schema: "target.sql"
 
   dropAndRecreateTable: false

--- a/src/test/resources/configuration/jobs/sqlserverimport/jobPostgres.yml
+++ b/src/test/resources/configuration/jobs/sqlserverimport/jobPostgres.yml
@@ -2,9 +2,9 @@ type: "sqlserver-bulk-import"
 configuration:
   extract:
     datasource: "postgres-testcontainer.yml"
-    query:  "sqlserverimport/source.sql"
+    query:  "source.sql"
 
   load:
     datasource: "sqlserver-testcontainer.yml"
     table: "encounter_types"
-    schema: "sqlserverimport/target.sql"
+    schema: "target.sql"

--- a/src/test/resources/configuration/jobs/sqlserverimport/jobWithContext.yml
+++ b/src/test/resources/configuration/jobs/sqlserverimport/jobWithContext.yml
@@ -2,12 +2,12 @@ type: "sqlserver-bulk-import"
 configuration:
   extract:
     datasource: "mysql-testcontainer.yml"
-    context: "sqlserverimport/context.sql"
-    query:  "sqlserverimport/encountersOfType.sql"
+    context: "context.sql"
+    query:  "encountersOfType.sql"
 
   load:
     datasource: "sqlserver-testcontainer.yml"
     table: "encounter_types"
-    schema: "sqlserverimport/target.sql"
+    schema: "target.sql"
 
 


### PR DESCRIPTION
Adds support for 2 new job types (sql-execution and iterating-job), which allow more flexibility of operations and flow, and more convenient and maintainable configuration where the same jobs need to be executed multiple times with small variations (eg. the source datasource).  Also adds in support for startupJobs, which are jobs that are always run at the time of application startup and before any scheduled job executions.  Finally adds in support within the iterating-job and job-pipeline job (which both execute multiple jobs) to determine whether these jobs run in series or in parallel, the number of concurrent threads to use in parallel, and whether a given job should be re-tried on failure.