### PR TITLE
PETL-115 - Iterating Jobs should always use parallel execution.

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,14 +322,9 @@ configuration:
 
 # job-pipeline
 
-A pipeline job allows combining multiple jobs together into a single job.  By default, this will run each defined 
-job in series, and will only execute jobs if those defined before it in the list execute successfully.  One can
-modify this behavior to run the listed jobs in parallel and independently of the success of prior jobs by setting 
-the ```maxConcurrentJobs``` property to a value greater than 1.
-
-```yaml
-maxConcurrentJobs: 5
-```
+A pipeline job allows combining multiple jobs together into a single job.  This will run each defined job in the order
+in which it is defined, in series, and will halt execution upon error, only executing subsequent jobs if 
+those defined before it in the list execute successfully.
 
 One can also control how errors are handled if encountered by nested jobs.  This is done via the ```errorHandling```
 configuration element as follows:
@@ -355,7 +350,6 @@ configuration:
         jobs:
           - "load-lower-neno.yml"
   execution:
-    maxConcurrentJobs: 1
     maxRetriesPerJob: 5
     retryInterval: 30
     retryIntervalUnit: "MINUTES"
@@ -369,10 +363,9 @@ An iterating job allows a single job template to be executed for multiple iterat
 different variables that can configure the job template.  Any aspect of the yaml configuration, or any nested configuration files
 can refer to a variable as ${variableName}, and this will be replaced by the specified value for each iteration.
 
-Like the job-pipeline job, an iterating-job also defaults to executing on job at a time, in series, in the order each iteration
-is listed in the configuration file, and will only execute jobs if those defined before it in the list execute successfully.  One can
-modify this behavior to run the listed jobs in parallel and independently of the success of prior jobs by setting
-the ```maxConcurrentJobs``` property to a value greater than 1.
+Unlike the job-pipeline job, an iterating-job will attempt to execute each job iteration, regardless of whether other
+iterations have failed.  By default, only one job is executed at at time, but this can be modified to allow more than one
+iteration to execute in parallel by adding a ```maxConcurrentJobs``` configuration property to a value greater than 1.
 
 ```yaml
 maxConcurrentJobs: 5

--- a/src/main/java/org/pih/petl/api/JobExecutor.java
+++ b/src/main/java/org/pih/petl/api/JobExecutor.java
@@ -28,19 +28,6 @@ public class JobExecutor {
         this.executorService = Executors.newScheduledThreadPool(maxConcurrentJobs);
     }
 
-
-    /**
-     * Execute a single task
-     */
-    public void execute(List<JobExecutionTask> tasks) throws InterruptedException, ExecutionException {
-        if (maxConcurrentJobs == 1) {
-            executeInSeries(tasks);
-        }
-        else {
-            executeInParallel(tasks);
-        }
-    }
-
     /**
      * Execute a single task
      */

--- a/src/main/java/org/pih/petl/job/IteratingJob.java
+++ b/src/main/java/org/pih/petl/job/IteratingJob.java
@@ -38,7 +38,7 @@ public class IteratingJob implements PetlJob {
                 iterationTasks.add(new JobExecutionTask(new ExecutionContext(context, childConfig)));
                 context.setStatus("Adding iteration task: " + iterationVars);
             }
-            jobExecutor.execute(iterationTasks);
+            jobExecutor.executeInParallel(iterationTasks);
         }
         finally {
             jobExecutor.shutdown();

--- a/src/main/java/org/pih/petl/job/RunMultipleJob.java
+++ b/src/main/java/org/pih/petl/job/RunMultipleJob.java
@@ -21,7 +21,7 @@ public class RunMultipleJob implements PetlJob {
     @Override
     public void execute(final ExecutionContext context) throws Exception {
         JobConfigReader configReader = new JobConfigReader(context);
-        JobExecutor jobExecutor = new JobExecutor(configReader.getInt(1, "maxConcurrentJobs"));
+        JobExecutor jobExecutor = new JobExecutor(1);
         try {
             List<JsonNode> jobTemplates = configReader.getList("jobs");
             context.setStatus("Executing " + jobTemplates.size() + " jobs");
@@ -30,7 +30,7 @@ public class RunMultipleJob implements PetlJob {
                 JobConfig childJobConfig = configReader.getJobConfig(jobTemplate);
                 tasks.add(new JobExecutionTask(new ExecutionContext(context, childJobConfig)));
             }
-            jobExecutor.execute(tasks);
+            jobExecutor.executeInSeries(tasks);
         }
         finally {
             jobExecutor.shutdown();

--- a/src/main/java/org/pih/petl/job/config/JobConfigReader.java
+++ b/src/main/java/org/pih/petl/job/config/JobConfigReader.java
@@ -129,7 +129,15 @@ public class JobConfigReader {
     public Integer getInt(Integer defaultValue, String...keys) {
         JsonNode n = get(keys);
         if (n != null) {
-            return n.asInt();
+            if (n.isInt()) {
+                return n.asInt();
+            }
+            else {
+                String stringVal = getString(n);
+                if (StringUtils.isNotEmpty(stringVal)) {
+                    return Integer.parseInt(stringVal);
+                }
+            }
         }
         return defaultValue;
     }

--- a/src/main/java/org/pih/petl/job/config/PetlConfig.java
+++ b/src/main/java/org/pih/petl/job/config/PetlConfig.java
@@ -4,10 +4,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
 /**
- * Configures how execution threading, concurrency, and retries on error should be handled
- * By default, an ExecutionConfig will specify no retries, and one concurrent job,
- * but this can be adjusted to support executing jobs in parallel, and configuring the number of times a job
- * execution should be attempted (i.e. to allow for retrying due to connectivity problems)
+ * Configures the specific PETL application defined properties
+ * All other properties are either user-defined or included with Spring boot
  */
 @Component
 @ConfigurationProperties("petl")

--- a/src/test/resources/configuration/jobs/execution/parallelExecution.yml
+++ b/src/test/resources/configuration/jobs/execution/parallelExecution.yml
@@ -1,30 +1,19 @@
-type: "job-pipeline"
+type: "iterating-job"
 configuration:
   maxConcurrentJobs: 3
-  jobs:
-    - type: "test-job"
-      errorHandling:
-        maxAttempts: 10
-        retryInterval: 100
-        retryIntervalUnit: "MILLISECONDS"
-      configuration:
-        testId: "parallelJob1"
-        simulateSuccessOnAttempt: 8
-    - type: "test-job"
-      errorHandling:
-        maxAttempts: 10
-        retryInterval: 100
-        retryIntervalUnit: "MILLISECONDS"
-      configuration:
-        testId: "parallelJob2"
-        simulateSuccessOnAttempt: 1
-    - type: "test-job"
-      errorHandling:
-        maxAttempts: 10
-        retryInterval: 100
-        retryIntervalUnit: "MILLISECONDS"
-      configuration:
-        testId: "parallelJob3"
-        simulateSuccessOnAttempt: 4
-
-
+  jobTemplate:
+    type: "test-job"
+    errorHandling:
+      maxAttempts: 10
+      retryInterval: 100
+      retryIntervalUnit: "MILLISECONDS"
+    configuration:
+      testId: "${testId}"
+      simulateSuccessOnAttempt: "${simulateSuccessOnAttempt}"
+  iterations:
+    - testId: "parallelJob1"
+      simulateSuccessOnAttempt: "8"
+    - testId: "parallelJob2"
+      simulateSuccessOnAttempt: "1"
+    - testId: "parallelJob3"
+      simulateSuccessOnAttempt: "4"

--- a/src/test/resources/configuration/jobs/execution/serialExecution.yml
+++ b/src/test/resources/configuration/jobs/execution/serialExecution.yml
@@ -1,6 +1,5 @@
 type: "job-pipeline"
 configuration:
-  maxConcurrentJobs: 1
   jobs:
     - type: "test-job"
       errorHandling:


### PR DESCRIPTION
This also fixes a bug in config reading of int values that use variables, and removes the ability to specify multiple executions in a pipeline (always runs serially).