### PR TITLE
Petl 116

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,19 @@ petl:
       - "job1.yml"
 ```
 
+* **PETL Startup Exit Automatically**:  PETL can be configured to startup, execute start jobs, and then exit.  To do so,
+    you configure this per below.  When executed in this way, successful execution will yield an exit code of 0, whereas 
+    an execution that results in errors will yield an exit code of 1.
+
+```yaml
+petl:
+  ...
+  startup:
+    jobs:
+      - "job1.yml"
+    exitAutomatically: true
+```
+
 * **Other server configuration**:
 
 ```yaml

--- a/src/main/java/org/pih/petl/PetlExitCodeGenerator.java
+++ b/src/main/java/org/pih/petl/PetlExitCodeGenerator.java
@@ -1,0 +1,31 @@
+package org.pih.petl;
+
+import org.springframework.boot.ExitCodeGenerator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PetlExitCodeGenerator implements ExitCodeGenerator {
+
+    private List<Throwable> exceptions = new ArrayList<>();
+
+    @Override
+    public int getExitCode() {
+        return exceptions.size();
+    }
+
+    public List<Throwable> getExceptions() {
+        if (exceptions == null) {
+            exceptions = new ArrayList<>();
+        }
+        return exceptions;
+    }
+
+    public void setExceptions(List<Throwable> exceptions) {
+        this.exceptions = exceptions;
+    }
+
+    public void addException(Throwable exception) {
+        getExceptions().add(exception);
+    }
+}

--- a/src/main/java/org/pih/petl/job/config/StartupConfig.java
+++ b/src/main/java/org/pih/petl/job/config/StartupConfig.java
@@ -15,6 +15,7 @@ import java.util.List;
 public class StartupConfig {
 
     private List<String> jobs;
+    private boolean exitAutomatically;
 
     public StartupConfig() {
     }
@@ -28,5 +29,13 @@ public class StartupConfig {
 
     public void setJobs(List<String> jobs) {
         this.jobs = jobs;
+    }
+
+    public boolean isExitAutomatically() {
+        return exitAutomatically;
+    }
+
+    public void setExitAutomatically(boolean exitAutomatically) {
+        this.exitAutomatically = exitAutomatically;
     }
 }


### PR DESCRIPTION
@mogoodrich / @cioan  / @jmbabazi this PR adds back in the ability to execute PETL to run specific jobs at startup, and then exit automatically.

This is intended to support our use case in Malawi, where we intend to execute the refresh-full.yml job at a specific time, and we want to execute this and have it exit, and to be able to easily detect whether once this exited if there were any errors are not.

You should be able to set the "petl.startup.exitAutomatically" property to true and the "petl.startup.jobs" property to the list of jobs to execute.  You should run via "java -jar petl.jar".

Once it executes, it will exit back to the terminal, and you can get the exit code by running `echo $?`.  This will return `0` if success, and `1` if failure.

