### PR TITLE
PETL-13 - Add ETL test tools with run-test.sh wrapper script

### DIFF
--- a/tools/CLAUDE.md
+++ b/tools/CLAUDE.md
@@ -1,0 +1,75 @@
+# ETL Test Tools — Development Notes
+
+This file captures conventions and architectural decisions for the `tools/` directory in the petl project.
+
+## What This Is
+
+A portable test harness for PIH ETL pipelines (sl-etl, zl-etl, malawi-etl, etc.). It spins up source and target database containers, imports a SQL dump, builds and runs the PETL pipeline, and saves the result log for comparison across runs.
+
+`run-test.sh` is intended to be **copied** into a working directory alongside `petl.jar`, `application.yml`, and the `containers/` directory. The `containers/` directory here serves as the canonical reference set of configurations.
+
+## How `run-test.sh` Discovers Things
+
+The script is pattern-driven, not hardcoded to specific DB variants. Given `--db-type mysql` and `--db-version 84` it expects:
+
+- **Compose file**: `containers/mysql_84.yml` (relative to the script's location)
+- **Scripts directory**: `containers/mysql/`
+- **ETL dir**: `{etl-base-dir}/{etl-project}` (defaults: `~/code/github/pih` and `sl-etl`)
+- **Project name**: `{etl-project}-{db-type}{db-version}` e.g. `sl-etl-mysql84` (passed to `docker compose -p`)
+- **Container name**: `{project}-{service}-1` where `{service}` is read dynamically from the compose file via `docker compose config --services`
+- **Naming convention**: hyphens are used consistently throughout — project names, container names, log filenames. No conversion between `-` and `_` is needed or performed.
+
+The service name in the compose file matters — it becomes part of the auto-generated container name. The script reads it at runtime so it doesn't need to be hardcoded.
+
+## Working Directory Layout
+
+When a user sets up their working directory they should have:
+
+```
+run-test.sh           # copied from tools/
+containers/           # copied from tools/containers/ (or a subset)
+petl.jar
+application.yml
+logs/
+```
+
+The script resolves all paths from `$SCRIPT_DIR` (the directory containing the script), so everything is relative to where it lives.
+
+## Adding a New Source DB Variant
+
+### Same type, new version (e.g. MySQL 9.1)
+
+1. Create `containers/mysql_91.yml` based on an existing MySQL compose file
+2. Adjust the `image:` tag and `command:` flags for the new version
+3. That's it — `run-test.sh` will find it automatically
+
+### New type entirely (e.g. Percona)
+
+1. Create `containers/percona_84.yml` with a service name of your choice
+2. Create `containers/percona/recreate-db.sh` and `containers/percona/import-db.sh`
+   - Scripts differ per type because they call the DB CLI tool by name (`mysql` vs `mariadb`)
+   - `recreate-db.sh` creates users and the database; see existing scripts for the pattern
+   - `import-db.sh` pipes the dump via `pv` into the container
+3. Pass `--db-type percona --db-version 84` to `run-test.sh`
+
+## Compose File Conventions
+
+- Omit `name:` and `container_name:` — project name is passed via `docker compose -p` at runtime
+- Source DBs all map to port `3308:3306` on the host; only one can run at a time
+- All compose files attach to the external `openmrs` Docker network (must be created once: `docker network create openmrs`)
+- The SQL Server target maps to `1433:1433`
+
+## Known Quirks
+
+- `containers/mariadb_118.yml` uses `mysql` as the service name (not `mariadb`). This is a holdover — it means the container is named e.g. `sl-etl-mariadb118-mysql-1`. Be consistent if adding new mariadb versions.
+- Source DB root credentials (`root`/`root`) are set in two places: the compose file `environment` block and hardcoded as `-proot` in the `recreate-db.sh` and `import-db.sh` scripts. If you change one, change both.
+- `application.yml` connection config must stay in sync with the compose files. Key values: source port `3308`, target port `1433`, target password matches `SA_PASSWORD` in `containers/sqlserver_2019/Dockerfile`.
+- The `recreate-db.sh` scripts use `CREATE USER` without `IF NOT EXISTS` for MySQL 5.6 compatibility (that syntax requires 5.7.6+). They suppress the "user already exists" error (1396) instead.
+
+## Target DB Variants
+
+The same pattern applies to target DBs. To add SQL Server 2022:
+
+1. Create `containers/sqlserver_2022/Dockerfile` and `entrypoint.sh` based on the 2019 versions
+2. Create `containers/sqlserver_2022.yml`
+3. Pass `--target-version 2022` to `run-test.sh`

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,152 @@
+# ETL Test Tools
+
+This directory contains tools for testing PIH ETL pipelines (sl-etl, zl-etl, malawi-etl, etc.) against different source database configurations (MySQL versions, MariaDB) and target databases (SQL Server).
+
+## Overview
+
+`run-test.sh` is a wrapper script that:
+
+1. Validates all inputs and preconditions before starting anything
+2. Starts a source database container, imports a SQL dump into it
+3. Starts a target database container
+4. Builds the ETL project from source and runs PETL against both containers
+5. Saves the run log to `logs/` for comparison across runs
+
+The script is **not meant to be run from this directory**. Copy it (along with `containers/`) into a working directory where you keep `petl.jar`, `application.yml`, and your logs.
+
+## Setting Up a Working Directory
+
+Create a directory for your test environment:
+
+```
+my-work-dir/
+  run-test.sh           # copied from tools/
+  containers/           # copied from tools/containers/
+  petl.jar              # download or build from the PETL project
+  application.yml       # PETL datasource configuration
+  logs/                 # created once, persists across runs
+```
+
+Copy the files:
+
+```bash
+mkdir -p ~/environments/sl-etl/logs
+cp tools/run-test.sh ~/environments/sl-etl/
+cp -r tools/containers ~/environments/sl-etl/
+```
+
+Then place `petl.jar` and `application.yml` in the working directory. The `application.yml` must configure datasource connections matching the compose files (source on port `3308`, SQL Server target on `1433`).
+
+## Prerequisites
+
+The following must be installed and available on your PATH:
+
+- `docker` (with the Compose plugin)
+- `java`
+- `mvn` (Maven)
+- `git`
+- `pv` (pipe viewer — used to show import progress; install with `sudo apt install pv` or `brew install pv`)
+
+The ETL source project(s) you intend to test must be cloned locally. By default the script looks under `~/code/github/pih/`, but this is configurable via `--etl-base-dir`.
+
+A Docker network named `openmrs` must exist. Create it once if it doesn't:
+
+```bash
+docker network create openmrs
+```
+
+## Running a Test
+
+From your working directory:
+
+```bash
+./run-test.sh \
+  --db-type <type> \
+  --db-version <version> \
+  --branch <etl-branch> \
+  --dump <path-to-sql-dump> \
+  [--etl-base-dir <path>] \
+  [--etl-project <name>] \
+  [--target-type <type>] \
+  [--target-version <version>] \
+  [--database <name>] \
+  [--log <log-filename>] \
+  [--teardown]
+```
+
+| Argument | Required | Default | Description |
+|---|---|---|---|
+| `--db-type` | Yes | | Source DB type (e.g. `mysql`, `mariadb`) |
+| `--db-version` | Yes | | Source DB version (e.g. `56`, `84`, `118`) |
+| `--branch` | Yes | | Branch of the ETL project to build and run |
+| `--dump` | Yes | | Path to the `.sql` dump file to import |
+| `--etl-base-dir` | No | `~/code/github/pih` | Base directory containing ETL project checkouts |
+| `--etl-project` | No | `sl-etl` | ETL project directory name within `--etl-base-dir` |
+| `--target-type` | No | `sqlserver` | Target DB type |
+| `--target-version` | No | `2019` | Target DB version |
+| `--database` | No | `kgh` | Source database name to create and import into |
+| `--log` | No | `{type}{version}-{branch}.log` | Output log filename under `logs/` |
+| `--teardown` | No | | Stop and remove containers after the run |
+
+### Examples
+
+```bash
+# MySQL 5.6, master branch (sl-etl default)
+./run-test.sh --db-type mysql --db-version 56 --branch master --dump kgh-2026-05-17.sql
+
+# MySQL 8.4, master branch
+./run-test.sh --db-type mysql --db-version 84 --branch master --dump kgh-2026-05-17.sql
+
+# MariaDB 11.8, mysql-upgrade branch, tear down when done
+./run-test.sh --db-type mariadb --db-version 118 --branch mysql-upgrade --dump kgh-2026-05-17.sql --teardown
+
+# Different ETL project
+./run-test.sh --etl-project zl-etl --db-type mysql --db-version 84 --branch master --dump zl-2026-05-17.sql
+
+# ETL project checked out outside the default base directory
+./run-test.sh --etl-base-dir /work/projects --etl-project malawi-etl --db-type mysql --db-version 84 --branch master --dump malawi-2026-05-17.sql
+```
+
+The script validates all inputs and preconditions before starting any containers or long-running commands. If anything is misconfigured it reports all errors at once and exits without making changes.
+
+## Monitoring
+
+While a run is in progress, watch for non-succeeded jobs in a separate terminal:
+
+```bash
+watch grep -v "SUCCEEDED" logs/petl-status.log
+```
+
+## Teardown
+
+If containers were not torn down automatically (i.e. `--teardown` was not passed), remove them manually when done:
+
+```bash
+docker compose -p sl-etl-mysql84 -f containers/mysql_84.yml down -v
+docker compose -p sl-etl-sqlserver2019 -f containers/sqlserver_2019.yml down -v
+```
+
+Adjust the project name and compose file to match whichever variant was run.
+
+## Available DB Variants
+
+| File | Description |
+|---|---|
+| `containers/mysql_56.yml` | MySQL 5.6 — 2G buffer pool |
+| `containers/mysql_84.yml` | MySQL 8.4 — 2G buffer pool |
+| `containers/mysql_84tuned.yml` | MySQL 8.4 — 6G buffer pool, extra tuning |
+| `containers/mariadb_118.yml` | MariaDB 11.8 — 2G buffer pool |
+| `containers/mariadb_118tuned.yml` | MariaDB 11.8 — 6G buffer pool, query cache 256M (**recommended**) |
+| `containers/mariadb_118aria.yml` | MariaDB 11.8 — same as tuned + Aria temp tables (not recommended; defeats query cache) |
+| `containers/sqlserver_2019.yml` | SQL Server 2019 (default target) |
+
+## Adding a New DB Variant
+
+To add a new source DB variant (e.g. MySQL 9.1):
+
+1. Add a compose file at `containers/mysql_91.yml` following the pattern of the existing MySQL files
+2. If it is a new DB type with different CLI tooling, add `recreate-db.sh` and `import-db.sh` scripts under `containers/<type>/`
+
+No changes to `run-test.sh` are needed.
+
+To add a new target DB variant, add a compose file at `containers/<type>_<version>.yml` and pass `--target-type` and `--target-version` accordingly.

--- a/tools/containers/mariadb/import-db.sh
+++ b/tools/containers/mariadb/import-db.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -eu
+
+CONTAINER="$1"
+DATABASE="$2"
+IMPORT_FILE="$3"
+
+echo "Importing into ${DATABASE} in ${CONTAINER} container from ${IMPORT_FILE}"
+pv ${IMPORT_FILE} | docker exec -i ${CONTAINER} sh -c "exec mariadb -u root -proot ${DATABASE}"
+

--- a/tools/containers/mariadb/recreate-db.sh
+++ b/tools/containers/mariadb/recreate-db.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -eu
+
+CONTAINER="$1"
+DATABASE="$2"
+
+# Create users if they don't exist; suppress "user already exists" error (1396) for idempotency.
+# Uses CREATE USER without IF NOT EXISTS for MySQL 5.6 compatibility (IF NOT EXISTS requires 5.7.6+).
+for USER in openmrs petldbadmin; do
+  echo "CREATE USER '${USER}'@'%';" \
+    | docker exec -i ${CONTAINER} mariadb -u root -proot 2>&1 \
+    | grep -v "ERROR 1396" || true
+done
+
+docker exec -i ${CONTAINER} mariadb -u root -proot <<SQL
+DROP DATABASE IF EXISTS ${DATABASE};
+CREATE DATABASE ${DATABASE} DEFAULT CHARSET utf8;
+GRANT ALL PRIVILEGES ON ${DATABASE}.* TO 'openmrs'@'%';
+GRANT ALL PRIVILEGES ON ${DATABASE}.* TO 'petldbadmin'@'%';
+FLUSH PRIVILEGES;
+SQL
+
+echo "$DATABASE dropped and recreated successfully in $CONTAINER container"

--- a/tools/containers/mariadb_118.yml
+++ b/tools/containers/mariadb_118.yml
@@ -1,0 +1,29 @@
+services:
+
+  mysql:
+    image: library/mariadb:11.8
+    environment:
+      - MYSQL_ROOT_PASSWORD=root
+    command: "mariadbd \
+              --innodb_default_row_format=DYNAMIC \
+              --character-set-server=utf8 \
+              --collation-server=utf8_general_ci \
+              --character-set-collations=utf8mb3=utf8mb3_general_ci \
+              --max_allowed_packet=1G \
+              --innodb-buffer-pool-size=2G \
+              --user=mysql \
+              --server-id=1 \
+              --skip-log-bin \
+              --sql_mode=STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"
+    volumes:
+      - "mysql_data:/var/lib/mysql"
+    ports:
+      - "3308:3306"
+
+volumes:
+  mysql_data:
+
+networks:
+  default:
+    name: "openmrs"
+    external: "true"

--- a/tools/containers/mariadb_118aria.yml
+++ b/tools/containers/mariadb_118aria.yml
@@ -1,0 +1,39 @@
+services:
+
+  mysql:
+    image: library/mariadb:11.8
+    environment:
+      - MYSQL_ROOT_PASSWORD=root
+    command: "mariadbd \
+              --innodb_default_row_format=DYNAMIC \
+              --character-set-server=utf8 \
+              --collation-server=utf8_general_ci \
+              --character-set-collations=utf8mb3=utf8mb3_general_ci \
+              --max_allowed_packet=1G \
+              --innodb-buffer-pool-size=6G \
+              --innodb-buffer-pool-instances=6 \
+              --tmp-table-size=512M \
+              --max-heap-table-size=512M \
+              --sort-buffer-size=4M \
+              --join-buffer-size=4M \
+              --innodb-read-io-threads=8 \
+              --query-cache-type=1 \
+              --query-cache-size=256M \
+              --aria-pagecache-buffer-size=256M \
+              --default-tmp-storage-engine=Aria \
+              --user=mysql \
+              --server-id=1 \
+              --skip-log-bin \
+              --sql_mode=STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"
+    volumes:
+      - "mysql_data:/var/lib/mysql"
+    ports:
+      - "3308:3306"
+
+volumes:
+  mysql_data:
+
+networks:
+  default:
+    name: "openmrs"
+    external: "true"

--- a/tools/containers/mariadb_118tuned.yml
+++ b/tools/containers/mariadb_118tuned.yml
@@ -1,0 +1,38 @@
+services:
+
+  mysql:
+    image: library/mariadb:11.8
+    environment:
+      - MYSQL_ROOT_PASSWORD=root
+    command: "mariadbd \
+              --innodb_default_row_format=DYNAMIC \
+              --character-set-server=utf8 \
+              --collation-server=utf8_general_ci \
+              --character-set-collations=utf8mb3=utf8mb3_general_ci \
+              --max_allowed_packet=1G \
+              --innodb-buffer-pool-size=6G \
+              --innodb-buffer-pool-instances=6 \
+              --tmp-table-size=512M \
+              --max-heap-table-size=512M \
+              --sort-buffer-size=4M \
+              --join-buffer-size=4M \
+              --innodb-read-io-threads=8 \
+              --query-cache-type=1 \
+              --query-cache-size=256M \
+              --aria-pagecache-buffer-size=256M \
+              --user=mysql \
+              --server-id=1 \
+              --skip-log-bin \
+              --sql_mode=STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"
+    volumes:
+      - "mysql_data:/var/lib/mysql"
+    ports:
+      - "3308:3306"
+
+volumes:
+  mysql_data:
+
+networks:
+  default:
+    name: "openmrs"
+    external: "true"

--- a/tools/containers/mysql/import-db.sh
+++ b/tools/containers/mysql/import-db.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -eu
+
+CONTAINER="$1"
+DATABASE="$2"
+IMPORT_FILE="$3"
+
+echo "Importing into ${DATABASE} in ${CONTAINER} container from ${IMPORT_FILE}"
+pv ${IMPORT_FILE} | docker exec -i ${CONTAINER} sh -c "exec mysql -u root -proot ${DATABASE}"
+

--- a/tools/containers/mysql/recreate-db.sh
+++ b/tools/containers/mysql/recreate-db.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -eu
+
+CONTAINER="$1"
+DATABASE="$2"
+
+# Create users if they don't exist; suppress "user already exists" error (1396) for idempotency.
+# Uses CREATE USER without IF NOT EXISTS for MySQL 5.6 compatibility (IF NOT EXISTS requires 5.7.6+).
+for USER in openmrs petldbadmin; do
+  echo "CREATE USER '${USER}'@'%';" \
+    | docker exec -i ${CONTAINER} mysql -u root -proot 2>&1 \
+    | grep -v "ERROR 1396" || true
+done
+
+docker exec -i ${CONTAINER} mysql -u root -proot <<SQL
+DROP DATABASE IF EXISTS ${DATABASE};
+CREATE DATABASE ${DATABASE} DEFAULT CHARSET utf8;
+GRANT ALL PRIVILEGES ON ${DATABASE}.* TO 'openmrs'@'%';
+GRANT ALL PRIVILEGES ON ${DATABASE}.* TO 'petldbadmin'@'%';
+FLUSH PRIVILEGES;
+SQL
+
+echo "$DATABASE dropped and recreated successfully in $CONTAINER container"

--- a/tools/containers/mysql_56.yml
+++ b/tools/containers/mysql_56.yml
@@ -1,0 +1,27 @@
+services:
+
+  mysql:
+    image: library/mysql:5.6
+    environment:
+      - MYSQL_ROOT_PASSWORD=root
+    command: "mysqld \
+              --character-set-server=utf8 \
+              --collation-server=utf8_general_ci \
+              --max_allowed_packet=1G \
+              --innodb-buffer-pool-size=2G \
+              --user=mysql \
+              --server-id=1 \
+              --net_write_timeout=3600 \
+              --net_read_timeout=3600"
+    volumes:
+      - "mysql_data:/var/lib/mysql"
+    ports:
+      - "3308:3306"
+
+volumes:
+  mysql_data:
+
+networks:
+  default:
+    name: "openmrs"
+    external: "true"

--- a/tools/containers/mysql_84.yml
+++ b/tools/containers/mysql_84.yml
@@ -1,0 +1,29 @@
+services:
+
+  mysql:
+    image: library/mysql:8.4
+    environment:
+      - MYSQL_ROOT_PASSWORD=root
+    command: "mysqld \
+              --character-set-server=utf8 \
+              --collation-server=utf8_general_ci \
+              --max_allowed_packet=1G \
+              --innodb-buffer-pool-size=2G \
+              --user=mysql \
+              --server-id=1 \
+              --skip-log-bin \
+              --mysql_native_password=ON \
+              --restrict_fk_on_non_standard_key=OFF \
+              --sql_mode=STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"
+    volumes:
+      - "mysql_data:/var/lib/mysql"
+    ports:
+      - "3308:3306"
+
+volumes:
+  mysql_data:
+
+networks:
+  default:
+    name: "openmrs"
+    external: "true"

--- a/tools/containers/mysql_84tuned.yml
+++ b/tools/containers/mysql_84tuned.yml
@@ -1,0 +1,35 @@
+services:
+
+  mysql:
+    image: library/mysql:8.4
+    environment:
+      - MYSQL_ROOT_PASSWORD=root
+    command: "mysqld \
+              --character-set-server=utf8 \
+              --collation-server=utf8_general_ci \
+              --max_allowed_packet=1G \
+              --innodb-buffer-pool-size=6G \
+              --innodb-buffer-pool-instances=6 \
+              --tmp-table-size=512M \
+              --max-heap-table-size=512M \
+              --sort-buffer-size=4M \
+              --join-buffer-size=4M \
+              --innodb-read-io-threads=8 \
+              --user=mysql \
+              --server-id=1 \
+              --skip-log-bin \
+              --mysql_native_password=ON \
+              --restrict_fk_on_non_standard_key=OFF \
+              --sql_mode=STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"
+    volumes:
+      - "mysql_data:/var/lib/mysql"
+    ports:
+      - "3308:3306"
+
+volumes:
+  mysql_data:
+
+networks:
+  default:
+    name: "openmrs"
+    external: "true"

--- a/tools/containers/sqlserver_2019.yml
+++ b/tools/containers/sqlserver_2019.yml
@@ -1,0 +1,9 @@
+services:
+
+  sqlserver:
+    build: ./sqlserver_2019
+    environment:
+      DATABASE_NAME: openmrs_reporting
+      SA_PASSWORD: "9%4qP7b2H!%J"
+    ports:
+      - "1433:1433"

--- a/tools/containers/sqlserver_2019/Dockerfile
+++ b/tools/containers/sqlserver_2019/Dockerfile
@@ -1,0 +1,11 @@
+FROM mcr.microsoft.com/mssql/server:2019-CU13-ubuntu-20.04
+
+ENV ACCEPT_EULA=Y
+ENV SA_PASSWORD="9%4qP7b2H!%J"
+ENV DATABASE_NAME="openmrs_reporting"
+
+COPY entrypoint.sh /
+COPY Dockerfile /
+
+ENTRYPOINT [ "/bin/bash", "entrypoint.sh" ]
+CMD [ "/opt/mssql/bin/sqlservr" ]

--- a/tools/containers/sqlserver_2019/entrypoint.sh
+++ b/tools/containers/sqlserver_2019/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+if [ "$1" = '/opt/mssql/bin/sqlservr' ]; then
+  if [ ! -f /tmp/db-initialized ]; then
+    function create_initial_database() {
+      sleep 5s
+      /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "${SA_PASSWORD}" -d master -Q "CREATE DATABASE ${DATABASE_NAME}"
+      touch /tmp/db-initialized
+    }
+    create_initial_database &
+  fi
+fi
+
+exec "$@"

--- a/tools/run-test.sh
+++ b/tools/run-test.sh
@@ -1,0 +1,184 @@
+#!/bin/bash -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+ETL_BASE_DIR="$HOME/code/github/pih"
+ETL_PROJECT="sl-etl"
+DB_TYPE=""
+DB_VERSION=""
+TARGET_TYPE="sqlserver"
+TARGET_VERSION="2019"
+BRANCH=""
+DUMP_FILE=""
+DATABASE="kgh"
+LOG_NAME=""
+TEARDOWN=false
+
+usage() {
+  echo "Usage: $0 --db-type <type> --db-version <version> --branch <branch> --dump <file> [--etl-base-dir <path>] [--etl-project <name>] [--target-type <type>] [--target-version <version>] [--database <name>] [--log <name>] [--teardown]"
+  echo "  e.g. $0 --db-type mysql --db-version 84 --branch master --dump kgh-2026-05-17.sql"
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --etl-base-dir)  ETL_BASE_DIR="$2";  shift 2 ;;
+    --etl-project)   ETL_PROJECT="$2";   shift 2 ;;
+    --db-type)       DB_TYPE="$2";       shift 2 ;;
+    --db-version)    DB_VERSION="$2";    shift 2 ;;
+    --target-type)   TARGET_TYPE="$2";   shift 2 ;;
+    --target-version) TARGET_VERSION="$2"; shift 2 ;;
+    --branch)        BRANCH="$2";        shift 2 ;;
+    --dump)          DUMP_FILE="$2";     shift 2 ;;
+    --database)      DATABASE="$2";      shift 2 ;;
+    --log)           LOG_NAME="$2";      shift 2 ;;
+    --teardown)      TEARDOWN=true;      shift   ;;
+    *) echo "Unknown argument: $1"; usage ;;
+  esac
+done
+
+[[ -z "$DB_TYPE" || -z "$DB_VERSION" || -z "$BRANCH" || -z "$DUMP_FILE" ]] && usage
+
+ETL_DIR="$ETL_BASE_DIR/$ETL_PROJECT"
+
+SOURCE_COMPOSE="$SCRIPT_DIR/containers/${DB_TYPE}_${DB_VERSION}.yml"
+TARGET_COMPOSE="$SCRIPT_DIR/containers/${TARGET_TYPE}_${TARGET_VERSION}.yml"
+DB_SCRIPTS="$SCRIPT_DIR/containers/${DB_TYPE}"
+SOURCE_PROJECT="${ETL_PROJECT}-${DB_TYPE}${DB_VERSION}"
+TARGET_PROJECT="${ETL_PROJECT}-${TARGET_TYPE}${TARGET_VERSION}"
+
+if [[ -z "$LOG_NAME" ]]; then
+  LOG_NAME="${DB_TYPE}${DB_VERSION}-${BRANCH}.log"
+fi
+
+# --- Validation ---
+
+ERRORS=0
+error() { echo "Error: $1"; ERRORS=$((ERRORS + 1)); }
+
+# Required commands
+for CMD in docker mvn java pv git; do
+  command -v "$CMD" &>/dev/null || error "Required command not found: $CMD"
+done
+
+# Docker daemon accessible
+docker info &>/dev/null || error "Docker daemon is not accessible"
+
+# Source compose file and scripts directory
+[[ -f "$SOURCE_COMPOSE" ]] || error "No source compose file found: $SOURCE_COMPOSE"
+[[ -d "$DB_SCRIPTS"     ]] || error "No scripts directory found: $DB_SCRIPTS"
+
+# Target compose file
+[[ -f "$TARGET_COMPOSE" ]] || error "No target compose file found: $TARGET_COMPOSE"
+
+# Derive container names and host ports from compose service names
+if [[ -f "$SOURCE_COMPOSE" ]]; then
+  SOURCE_SERVICE=$(docker compose -f "$SOURCE_COMPOSE" config --services 2>/dev/null | head -1)
+  [[ -n "$SOURCE_SERVICE" ]] || error "Could not determine service name from $SOURCE_COMPOSE"
+  SOURCE_PORT=$(docker compose -f "$SOURCE_COMPOSE" config 2>/dev/null | grep 'published:' | head -1 | awk '{print $2}' | tr -d '"')
+fi
+if [[ -f "$TARGET_COMPOSE" ]]; then
+  TARGET_SERVICE=$(docker compose -f "$TARGET_COMPOSE" config --services 2>/dev/null | head -1)
+  [[ -n "$TARGET_SERVICE" ]] || error "Could not determine service name from $TARGET_COMPOSE"
+  TARGET_PORT=$(docker compose -f "$TARGET_COMPOSE" config 2>/dev/null | grep 'published:' | head -1 | awk '{print $2}' | tr -d '"')
+fi
+
+SOURCE_CONTAINER="${SOURCE_PROJECT}-${SOURCE_SERVICE:-unknown}-1"
+TARGET_CONTAINER="${TARGET_PROJECT}-${TARGET_SERVICE:-unknown}-1"
+
+# Dump file
+[[ -f "$DUMP_FILE" ]] || error "Dump file not found: $DUMP_FILE"
+
+# Working directory contents
+[[ -f "$SCRIPT_DIR/petl.jar" ]] || error "petl.jar not found at $SCRIPT_DIR/petl.jar"
+[[ -d "$SCRIPT_DIR/logs"     ]] || error "Logs directory not found: $SCRIPT_DIR/logs"
+[[ ! -f "$SCRIPT_DIR/logs/petl-status.log" ]] || error "logs/petl-status.log already exists from a previous run; rename or remove it first"
+[[ ! -f "$SCRIPT_DIR/logs/$LOG_NAME"       ]] || error "Log file already exists: $SCRIPT_DIR/logs/$LOG_NAME"
+
+# ETL directory and branch
+if [[ ! -d "$ETL_DIR" ]]; then
+  error "ETL directory not found: $ETL_DIR"
+else
+  CURRENT_BRANCH=$(git -C "$ETL_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null) || { error "Could not determine git branch in $ETL_DIR"; CURRENT_BRANCH=""; }
+  [[ "$CURRENT_BRANCH" == "$BRANCH" ]] || error "ETL project is on branch '$CURRENT_BRANCH', expected '$BRANCH'"
+  if ! git -C "$ETL_DIR" diff --quiet || ! git -C "$ETL_DIR" diff --cached --quiet; then
+    echo "Warning: ETL project has uncommitted changes"
+  fi
+fi
+
+# Docker network
+docker network inspect openmrs &>/dev/null || error "Docker network 'openmrs' does not exist"
+
+# Containers must not already exist
+docker ps -a --format '{{.Names}}' | grep -qx "$SOURCE_CONTAINER" && error "Container '$SOURCE_CONTAINER' already exists"
+docker ps -a --format '{{.Names}}' | grep -qx "$TARGET_CONTAINER" && error "Container '$TARGET_CONTAINER' already exists"
+
+# Host ports must not already be bound
+[[ -n "$SOURCE_PORT" ]] && docker ps --format '{{.Ports}}' | grep -q ":${SOURCE_PORT}->" && error "Port $SOURCE_PORT is already bound by a running container"
+[[ -n "$TARGET_PORT" ]] && docker ps --format '{{.Ports}}' | grep -q ":${TARGET_PORT}->" && error "Port $TARGET_PORT is already bound by a running container"
+
+if [[ $ERRORS -gt 0 ]]; then
+  echo "$ERRORS validation error(s) found. Aborting."
+  exit 1
+fi
+
+wait_for_mysql() {
+  local container="$1"
+  local client="$2"
+  local timeout=120
+  local elapsed=0
+  echo "Waiting for database to be ready in $container..."
+  until docker exec "$container" "$client" -u root -proot -e "SELECT 1" &>/dev/null; do
+    if [[ $elapsed -ge $timeout ]]; then
+      echo "Error: Database in $container did not become ready within ${timeout}s"
+      exit 1
+    fi
+    sleep 2
+    elapsed=$((elapsed + 2))
+  done
+  echo "Database is ready."
+}
+
+wait_for_sqlserver() {
+  local container="$1"
+  local timeout=120
+  local elapsed=0
+  echo "Waiting for SQL Server database to be ready in $container..."
+  until docker exec "$container" bash -c \
+    '/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "$SA_PASSWORD" -d "$DATABASE_NAME" -Q "SELECT 1"' \
+    &>/dev/null; do
+    if [[ $elapsed -ge $timeout ]]; then
+      echo "Error: SQL Server in $container did not become ready within ${timeout}s"
+      exit 1
+    fi
+    sleep 2
+    elapsed=$((elapsed + 2))
+  done
+  echo "SQL Server is ready."
+}
+
+echo "Starting test run: etl=$ETL_PROJECT source=${DB_TYPE}${DB_VERSION} target=${TARGET_TYPE}${TARGET_VERSION} branch=$BRANCH database=$DATABASE log=logs/$LOG_NAME"
+
+case "$DB_TYPE" in
+  mariadb) DB_CLIENT="mariadb" ;;
+  *)       DB_CLIENT="mysql"   ;;
+esac
+
+docker compose -p "$SOURCE_PROJECT" -f "$SOURCE_COMPOSE" up -d
+wait_for_mysql "$SOURCE_CONTAINER" "$DB_CLIENT"
+"$DB_SCRIPTS/recreate-db.sh" "$SOURCE_CONTAINER" "$DATABASE"
+"$DB_SCRIPTS/import-db.sh" "$SOURCE_CONTAINER" "$DATABASE" "$DUMP_FILE"
+
+docker compose -p "$TARGET_PROJECT" -f "$TARGET_COMPOSE" up -d
+wait_for_sqlserver "$TARGET_CONTAINER"
+
+mvn -f "$ETL_DIR" clean install
+java -jar "$SCRIPT_DIR/petl.jar"
+
+mv "$SCRIPT_DIR/logs/petl-status.log" "$SCRIPT_DIR/logs/$LOG_NAME"
+echo "Log saved to $SCRIPT_DIR/logs/$LOG_NAME"
+
+if $TEARDOWN; then
+  docker compose -p "$TARGET_PROJECT" -f "$TARGET_COMPOSE" down -v
+  docker compose -p "$SOURCE_PROJECT" -f "$SOURCE_COMPOSE" down -v
+fi


### PR DESCRIPTION
Adds a tools/ directory with a pattern-based test harness for running ETL pipelines against different source DB configurations (MySQL 5.6/8.4, MariaDB 11.8) and SQL Server targets. The script is designed to be copied into a working directory alongside petl.jar and application.yml.